### PR TITLE
Fix: Correct video preview and button lifecycle in WebcamRecorder

### DIFF
--- a/src/components/recipient/WebcamRecorder.tsx
+++ b/src/components/recipient/WebcamRecorder.tsx
@@ -112,13 +112,17 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
       setRecordingCompleted(true);
       setIsRecording(false);
       onRecordingComplete(recordedBlob);
+      stopWebcam(); // Add this line to deactivate the webcam
 
+      // The following lines that manually stop tracks on videoRef.current.srcObject
+      // might become redundant if stopWebcam() already handles stream track stopping.
+      // For now, we can leave them, but it's something to note.
       if (videoRef.current?.srcObject) {
         (videoRef.current.srcObject as MediaStream).getTracks().forEach(track => track.stop());
         videoRef.current.srcObject = null;
       }
     }
-  }, [recordingStatus, recordedBlob, recordingCompleted]);
+  }, [recordingStatus, recordedBlob, recordingCompleted, onRecordingComplete, stopWebcam]); // Add onRecordingComplete and stopWebcam
 
   useEffect(() => {
     let interval: NodeJS.Timeout;
@@ -151,11 +155,15 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
   }, [showCountdown, countdownValue, stream]);
 
   useEffect(() => {
-    // When recording begins, auto-hide preview if requested and not manually toggled
-    if (isRecording && hidePreviewAfterCountdown && !previewManuallyToggled) {
+    // When recording begins or countdown finishes, auto-hide preview if requested and not manually toggled
+    if (
+      (isRecording || !showCountdown) &&
+      hidePreviewAfterCountdown &&
+      !previewManuallyToggled
+    ) {
       setShowPreview(false);
     }
-  }, [isRecording, hidePreviewAfterCountdown, previewManuallyToggled]);
+  }, [isRecording, showCountdown, hidePreviewAfterCountdown, previewManuallyToggled]);
 
   useEffect(() => {
     if (showCountdown) setCountdownValue(countdownDuration);
@@ -222,7 +230,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
     <div className={classNames('flex flex-col items-center', className || '')}>
       <h2 className="text-xl font-semibold mb-2">Record Your Reaction</h2>
 
-      {(showPreview || (!previewManuallyToggled && (showCountdown || isRecording))) && (
+      {((showCountdown && !previewManuallyToggled) || showPreview) && (
         <div className="w-full max-w-md my-4">
           <video
             ref={videoRef}
@@ -244,7 +252,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
       {recordingCompleted && (
         <p className="text-green-600 mt-2">Recording complete!</p>
       )}
-      {isRecording && !recordingCompleted && (
+      {isRecording && (
         <button
           className="text-sm text-primary-600 underline mt-2"
           onClick={() => {


### PR DESCRIPTION
This commit refines the visibility logic for the video preview element and the show/hide preview button in `WebcamRecorder.tsx` to align with specific user requirements:

1.  Video Preview Visibility:
    - Ensures the video preview is visible by default during the countdown phase.
    - Correctly auto-hides after the countdown if not manually interacted with.
    - Responds to manual toggling via the show/hide button.
    - This was achieved by refining the conditional rendering logic for the video preview wrapper to: `((showCountdown && !previewManuallyToggled) || showPreview)`

2.  Show/Hide Preview Button Lifecycle:
    - The button is hidden before and during the countdown.
    - The button appears only after the countdown finishes and recording starts.
    - Upon appearing, its text correctly defaults to "Show Preview" (reflecting the auto-hidden preview).
    - The button correctly toggles the preview and its own text.
    - The button is hidden again when the recording session completes.
    - This was achieved by conditioning the button's rendering on the `isRecording` state.

These changes ensure a more intuitive and precise user experience for managing the webcam preview throughout the recording process.