### PR TITLE
refactor: Enhance 'beforeunload' warning to cover active upload

### DIFF
--- a/src/components/recipient/WebcamRecorder.tsx
+++ b/src/components/recipient/WebcamRecorder.tsx
@@ -18,6 +18,7 @@ interface WebcamRecorderProps {
   triggerCountdownSignal?: boolean;
   onStatusUpdate?: (message: string | null) => void;
   onWebcamError?: (message: string | null) => void;
+  isUploading?: boolean; // New prop
 }
 
 const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
@@ -34,6 +35,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
   triggerCountdownSignal,
   onStatusUpdate,
   onWebcamError,
+  isUploading = false, // Destructure the new prop
 }) => {
   const [showCountdown, setShowCountdown] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
@@ -277,6 +279,25 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
       setShowCountdown(true);
     }
   }, [triggerCountdownSignal, webcamInitialized, stream, isRecording, recordingCompleted]);
+
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (isRecording || isUploading) { // Condition updated
+        event.preventDefault();
+        event.returnValue = 'Your video is still being processed. Are you sure you want to leave?';
+      }
+    };
+
+    if (isRecording || isUploading) { // Condition updated
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    } else {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    }
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isRecording, isUploading]); // Dependency array updated
 
   const handleRetryWebcam = () => {
     setWebcamInitialized(false);


### PR DESCRIPTION
This commit refines the 'beforeunload' warning functionality for video reactions.

Previously, the warning in `WebcamRecorder.tsx` considered `isRecording` and `recordingCompleted`. This did not fully cover the actual upload period if the parent component handled the upload asynchronously.

Changes:
- `WebcamRecorder.tsx`:
    - Added a new optional boolean prop `isUploading`.
    - The `beforeunload` event listener is now triggered if `isRecording` is true OR `isUploading` (passed from parent) is true.
    - `recordingCompleted` state is no longer used for this specific warning logic.

- `MessageViewer.tsx`:
    - Manages a new `isUploading` state variable.
    - `isUploading` is set to `true` before the call to `reactionsApi.uploadVideoToReaction` and set to `false` in the `finally` block, ensuring it's reset after success or failure.
    - Passes the `isUploading` state to the `WebcamRecorder` component.

This ensures you are warned against navigating away not only during recording but also throughout the actual video upload process, reducing the risk of data loss.