### PR TITLE
Refactor: Remove commented-out console.log statements

### DIFF
--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -99,7 +99,6 @@
       
 //       for (const key of possibleLinkKeys) {
 //         if (response.data[key]) {
-//           //console.log(`Found shareable link with key "${key}":`, response.data[key]);
 //           setShareableLink(response.data[key]);
 //           linkFound = true;
 //           break;
@@ -358,8 +357,6 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
 
       // Add reaction length
       formData.append('reaction_length', data.reaction_length.toString());
-      
-      //console.log('Form data being sent:', Object.fromEntries(formData.entries()));
       
       // Call API to create message with FormData
       const response = await messagesApi.createWithFormData(formData);


### PR DESCRIPTION
I removed two commented-out console.log statements from MessageForm.tsx.

These logs appeared to be for debugging purposes and were not active. This change contributes to code cleanliness. No active logging was removed as I didn't find any excessive active logging in the codebase.