### PR TITLE
Use icon for QR toggle in message page

### DIFF
--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -459,9 +459,26 @@ const Message: React.FC = () => {
                       </button>
                       <button
                         onClick={() => setShowQrCode(!showQrCode)}
-                        className="ml-2 rounded-md bg-green-600 p-2 text-white hover:bg-green-700"
+                        aria-label={showQrCode ? 'Hide QR Code' : 'Show QR Code'}
+                        className={`ml-2 rounded-md p-2 transition-colors ${
+                          showQrCode
+                            ? 'bg-neutral-300 text-neutral-800 hover:bg-neutral-400 dark:bg-neutral-600 dark:text-white dark:hover:bg-neutral-500'
+                            : 'bg-green-600 text-white hover:bg-green-700'
+                        }`}
                       >
-                        {showQrCode ? 'Hide QR' : 'Show QR'}
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-4 w-4"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z"
+                            clipRule="evenodd"
+                          />
+                          <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z" />
+                        </svg>
                       </button>
                     </div>
                     {copied.link && (


### PR DESCRIPTION
## Summary
- replace the Show/Hide QR text button with a QR icon button
- change styles to visually indicate when the QR code is visible

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684930035ff883249e0f72b439ed643c