### PR TITLE
Add guest user banner

### DIFF
--- a/src/components/common/GuestBanner.tsx
+++ b/src/components/common/GuestBanner.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useAuth } from '../../context/AuthContext';
+
+const GuestBanner: React.FC = () => {
+  const { user } = useAuth();
+
+  if (!user || user.role !== 'guest') {
+    return null;
+  }
+
+  const { maxMessagesPerMonth, maxReactionsPerMonth, maxReactionsPerMessage } = user;
+
+  return (
+    <div className="bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-300 text-sm text-center p-2">
+      You are a guest user and are limited to {maxMessagesPerMonth ?? 0} messages, {maxReactionsPerMonth ?? 0} total reactions and {maxReactionsPerMessage ?? 0} reactions per message. To upgrade please contact{' '}
+      <a href="mailto:support@reactlyve.com" className="underline">support@reactlyve.com</a>.
+    </div>
+  );
+};
+
+export default GuestBanner;

--- a/src/layouts/DashboardLayout.tsx
+++ b/src/layouts/DashboardLayout.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import Navbar from '../components/common/Navbar';
 import Footer from '../components/common/Footer'; // New import
+import GuestBanner from '../components/common/GuestBanner';
 import { classNames } from '../utils/classNames';
 
 interface DashboardLayoutProps {
@@ -64,7 +65,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50 dark:bg-neutral-900">
       <Navbar />
-      
+      <GuestBanner />
+
       <div className="flex flex-1 max-w-screen-xl mx-auto w-full">
         {/* Mobile sidebar toggle and related elements removed */}
             

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Navbar from '../components/common/Navbar';
 import Footer from '../components/common/Footer';
+import GuestBanner from '../components/common/GuestBanner';
 import { classNames } from '../utils/classNames';
 
 interface MainLayoutProps {
@@ -19,6 +20,7 @@ const MainLayout: React.FC<MainLayoutProps> = ({
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50 dark:bg-neutral-900">
       {!hideNavbar && <Navbar />}
+      <GuestBanner />
       <main className={classNames('flex-grow', className || '')}>
         {children}
       </main>


### PR DESCRIPTION
## Summary
- show a banner to guest users
- include the banner in MainLayout and DashboardLayout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6849415559bc83249291768b8285c9cd