### PR TITLE
Fix updateUserModeration route

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -185,11 +185,16 @@ export const adminApi = {
     const response = await api.put(`/admin/users/${userId}/limits`, limits);
     return response;
   },
+  // The backend does not expose a dedicated /moderation endpoint.
+  // Moderation flags are updated via the same limits route.
   updateUserModeration: async (
     userId: string,
     moderation: UpdateUserModerationPayload,
   ) => {
-    const response = await api.put(`/admin/users/${userId}/moderation`, moderation);
+    const response = await api.put(
+      `/admin/users/${userId}/limits`,
+      moderation,
+    );
     return response;
   },
   getModerationSummary: async () => {


### PR DESCRIPTION
## Summary
- fix admin API call for updating user moderation settings

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 503 Service Unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_684b2ab4b81483249a39df37036dbf82