### PR TITLE
Fix Cloudinary transformation constant

### DIFF
--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -1,7 +1,7 @@
 // src/utils/mediaHelpers.ts
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = "f_auto,q_auto,l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10";
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = "w_1280,c_limit,q_auto,f_auto,l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10";
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = 'f_auto,q_auto/l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10';
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = 'w_1280,c_limit,q_auto,f_auto/l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10';
 
 /**
  * Request camera and microphone permissions


### PR DESCRIPTION
## Summary
- ensure Cloudinary transformation constants use a slash separator

## Testing
- `npm run lint` *(fails: 217 errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684b33f8710c8324a08ef72cb0bfedd2