### PR TITLE
Improve recording visuals with pulsing border

### DIFF
--- a/src/components/common/RecordingBorder.tsx
+++ b/src/components/common/RecordingBorder.tsx
@@ -10,7 +10,7 @@ const RecordingBorder: React.FC<RecordingBorderProps> = ({ isVisible }) => {
   }
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50 rounded-md border-4 border-red-500 animate-record-glow" />
+    <div className="pointer-events-none fixed inset-0 z-50 rounded-md border-[12px] md:border-[20px] border-red-500 animate-record-glow-md md:animate-record-glow-lg" />
   );
 };
 

--- a/src/components/common/RecordingBorder.tsx
+++ b/src/components/common/RecordingBorder.tsx
@@ -10,7 +10,9 @@ const RecordingBorder: React.FC<RecordingBorderProps> = ({ isVisible }) => {
   }
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50 rounded-md border-[12px] md:border-[20px] border-red-500 animate-record-glow-md md:animate-record-glow-lg" />
+    <div
+      className="pointer-events-none fixed inset-0 z-50 rounded-xl border-record-mobile md:border-record-desktop border-red-500 animate-record-glow-md md:animate-record-glow-lg"
+    />
   );
 };
 

--- a/src/components/common/RecordingBorder.tsx
+++ b/src/components/common/RecordingBorder.tsx
@@ -1,88 +1,16 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 
 interface RecordingBorderProps {
   isVisible: boolean;
 }
 
 const RecordingBorder: React.FC<RecordingBorderProps> = ({ isVisible }) => {
-  const [isPortrait, setIsPortrait] = useState(true);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsPortrait(window.innerHeight > window.innerWidth);
-    };
-    window.addEventListener('resize', handleResize);
-    handleResize(); // Initial check
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
   if (!isVisible) {
     return null;
   }
 
-  const DURATION_SHORT_SIDE_S = 2.5;
-  const DURATION_LONG_SIDE_S = 5;
-
-  const topBottomDuration = isPortrait ? DURATION_SHORT_SIDE_S : DURATION_LONG_SIDE_S;
-  const leftRightDuration = isPortrait ? DURATION_LONG_SIDE_S : DURATION_SHORT_SIDE_S;
-
-  const delayRightS = topBottomDuration;
-  const delayBottomS = topBottomDuration + leftRightDuration;
-  const delayLeftS = topBottomDuration + leftRightDuration + topBottomDuration;
-
   return (
-    <>
-      {/* Static Borders (Width 1) */}
-      <div className="fixed top-0 left-0 right-0 h-1 bg-red-500 z-40" /> {/* Top - Changed to h-1 */}
-      <div className="fixed top-0 bottom-0 right-0 w-1 bg-red-500 z-40" /> {/* Right - Changed to w-1 */}
-      <div className="fixed bottom-0 left-0 right-0 h-1 bg-red-500 z-40" /> {/* Bottom - Changed to h-1 */}
-      <div className="fixed top-0 bottom-0 left-0 w-1 bg-red-500 z-40" /> {/* Left - Changed to w-1 */}
-
-      {/* Animated "Snake" Borders (Width 2) */}
-      {/* Top Animated */}
-      <div
-        className="fixed top-0 left-0 h-2 bg-red-500 animate-snake-border-top z-50" // Changed to h-2
-        style={{
-          animationDuration: `${topBottomDuration}s`,
-          animationTimingFunction: 'ease-in-out',
-          animationFillMode: 'forwards',
-          animationIterationCount: 'infinite',
-        }}
-      />
-      {/* Right Animated */}
-      <div
-        className="fixed top-0 right-0 w-2 bg-red-500 animate-snake-border-right z-50" // Changed to w-2
-        style={{
-          animationDuration: `${leftRightDuration}s`,
-          animationDelay: `${delayRightS}s`,
-          animationTimingFunction: 'ease-in-out',
-          animationFillMode: 'forwards',
-          animationIterationCount: 'infinite',
-        }}
-      />
-      {/* Bottom Animated */}
-      <div
-        className="fixed bottom-0 right-0 h-2 bg-red-500 animate-snake-border-bottom z-50" // Changed to h-2
-        style={{
-          animationDuration: `${topBottomDuration}s`,
-          animationDelay: `${delayBottomS}s`,
-          animationTimingFunction: 'ease-in-out',
-          animationFillMode: 'forwards',
-          animationIterationCount: 'infinite',
-        }}
-      />
-      {/* Left Animated */}
-      <div
-        className="fixed bottom-0 left-0 w-2 bg-red-500 animate-snake-border-left z-50" // Changed to w-2
-        style={{
-          animationDuration: `${leftRightDuration}s`,
-          animationDelay: `${delayLeftS}s`,
-          animationTimingFunction: 'ease-in-out',
-          animationFillMode: 'forwards',
-          animationIterationCount: 'infinite',
-        }}
-      />
-    </>
+    <div className="pointer-events-none fixed inset-0 z-50 rounded-md border-4 border-red-500 animate-record-glow" />
   );
 };
 

--- a/src/components/common/RecordingBorder.tsx
+++ b/src/components/common/RecordingBorder.tsx
@@ -10,9 +10,9 @@ const RecordingBorder: React.FC<RecordingBorderProps> = ({ isVisible }) => {
   }
 
   return (
-    <div
-      className="pointer-events-none fixed inset-0 z-50 rounded-xl border-record-mobile md:border-record-desktop border-red-500 animate-record-glow-md md:animate-record-glow-lg"
-    />
+    <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
+      <div className="absolute inset-0 rounded-xl animate-record-glow-md md:animate-record-glow-lg" />
+    </div>
   );
 };
 

--- a/src/components/common/RecordingBorder.tsx
+++ b/src/components/common/RecordingBorder.tsx
@@ -11,6 +11,7 @@ const RecordingBorder: React.FC<RecordingBorderProps> = ({ isVisible }) => {
 
   return (
     <div className="pointer-events-none fixed inset-0 z-50 overflow-hidden">
+      <div className="absolute inset-0 border-4 md:border-[7px] border-red-500" />
       <div className="absolute inset-0 rounded-xl animate-record-glow-md md:animate-record-glow-lg" />
     </div>
   );

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -283,7 +283,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
 
   if (!passcodeVerified && message.hasPasscode) {
     return (
-      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900">
         <PasscodeEntry onSubmitPasscode={handlePasscodeSubmit} />
       </div>
     );
@@ -293,7 +293,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
       // Dedicated UI for Reaction Limit Error
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
           <div className="card mx-auto max-w-md p-6 text-center"> {/* Ensure 'card' class provides appropriate styling */}
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -321,7 +321,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       );
     } else if (permissionError === MESSAGE_ERRORS.CONTENT_UNAVAILABLE) {
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
           <div className="card mx-auto max-w-md p-6 text-center">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -337,7 +337,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     } else {
       // Fallback to PermissionRequest for other errors that might use this state
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
           <PermissionRequest
             onCancel={() => onSkipReaction?.()}
             permissionType="both" // This is still hardcoded; might need review later if other errors use this path
@@ -492,7 +492,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       <RecordingBorder isVisible={isWebcamRecording} />
       <div
         className={
-        "flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8"
+        "flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6"
         }
       >
         {showRecorder && !isReactionRecorded && (

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -283,7 +283,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
 
   if (!passcodeVerified && message.hasPasscode) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
         <PasscodeEntry onSubmitPasscode={handlePasscodeSubmit} />
       </div>
     );
@@ -293,7 +293,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
       // Dedicated UI for Reaction Limit Error
       return (
-        <div className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
           <div className="card mx-auto max-w-md p-6 text-center"> {/* Ensure 'card' class provides appropriate styling */}
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -321,7 +321,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       );
     } else if (permissionError === MESSAGE_ERRORS.CONTENT_UNAVAILABLE) {
       return (
-        <div className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
           <div className="card mx-auto max-w-md p-6 text-center">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -337,7 +337,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     } else {
       // Fallback to PermissionRequest for other errors that might use this state
       return (
-        <div className="flex min-h-screen w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
           <PermissionRequest
             onCancel={() => onSkipReaction?.()}
             permissionType="both" // This is still hardcoded; might need review later if other errors use this path
@@ -491,7 +491,9 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     <>
       <RecordingBorder isVisible={isWebcamRecording} />
       <div
-        className={"flex min-h-screen w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12"}
+        className={
+          "flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12"
+        }
       >
         {showRecorder && !isReactionRecorded && (
           <div className="w-full max-w-md mx-auto mb-4">

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -283,7 +283,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
 
   if (!passcodeVerified && message.hasPasscode) {
     return (
-      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900">
         <PasscodeEntry onSubmitPasscode={handlePasscodeSubmit} />
       </div>
     );
@@ -293,7 +293,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
       // Dedicated UI for Reaction Limit Error
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
           <div className="card mx-auto max-w-md p-6 text-center"> {/* Ensure 'card' class provides appropriate styling */}
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -321,7 +321,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       );
     } else if (permissionError === MESSAGE_ERRORS.CONTENT_UNAVAILABLE) {
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
           <div className="card mx-auto max-w-md p-6 text-center">
             <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
               <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -337,7 +337,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     } else {
       // Fallback to PermissionRequest for other errors that might use this state
       return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
+        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8">
           <PermissionRequest
             onCancel={() => onSkipReaction?.()}
             permissionType="both" // This is still hardcoded; might need review later if other errors use this path
@@ -492,7 +492,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       <RecordingBorder isVisible={isWebcamRecording} />
       <div
         className={
-          "flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12"
+        "flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-4 dark:bg-neutral-900 sm:py-8"
         }
       >
         {showRecorder && !isReactionRecorded && (

--- a/src/components/recipient/WebcamRecorder.tsx
+++ b/src/components/recipient/WebcamRecorder.tsx
@@ -1,6 +1,6 @@
 import { FFmpeg, FileData } from '@ffmpeg/ffmpeg'; // Added
 import { fetchFile, toBlobURL } from '@ffmpeg/util'; // Added
-import React, { useState, useEffect, useRef } from 'react'; // Added useRef
+import React, { useState, useEffect, useRef } from 'react';
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
 import useWebcam from '../../hooks/useWebcam';
 import useMediaRecorder from '../../hooks/useMediaRecorder';
@@ -51,6 +51,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
 }) => {
   const ffmpegRef = useRef(new FFmpeg()); // Added
   const stopWebcamRef = useRef<() => void>();
+  const containerRef = useRef<HTMLDivElement>(null);
   const [isCompressing, setIsCompressing] = useState<boolean>(false); // Added
   const [compressionProgress, setCompressionProgress] = useState<number>(0); // Added
   const [showCountdown, setShowCountdown] = useState(false);
@@ -426,6 +427,13 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
     }
   }, [isRecording, showCountdown, hidePreviewAfterCountdown, previewManuallyToggled]);
 
+  // Ensure the countdown preview is vertically centered when shown
+  useEffect(() => {
+    if (showCountdown && containerRef.current) {
+      containerRef.current.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+  }, [showCountdown]);
+
   useEffect(() => {
     if (showCountdown) setCountdownValue(countdownDuration);
   }, [showCountdown, countdownDuration]);
@@ -547,6 +555,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
       {' '}
       {/* Use a fragment if adding the overlay as a sibling to the main div */}
       <div
+        ref={containerRef}
         className={classNames(
           'relative flex flex-col items-center justify-center text-center',
           className || ''

--- a/src/components/recipient/WebcamRecorder.tsx
+++ b/src/components/recipient/WebcamRecorder.tsx
@@ -553,11 +553,11 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
         )}
       >
         {!(showCountdown || isRecording || recordingCompleted || isCompressing) && (
-          <h2 className="mb-2 text-xl font-semibold">Record Your Lyve Reaction</h2>
+          <h2 className="mb-1 text-lg font-semibold">Record Your Lyve Reaction</h2>
         )}
 
         {((showCountdown && !previewManuallyToggled) || showPreview) && (
-          <div className="aspect-video relative mb-4 mt-2 w-full max-w-md">
+          <div className="aspect-video relative mb-3 mt-1 w-full max-w-md">
             <video
               ref={videoRef}
               autoPlay
@@ -608,7 +608,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
               setShowPreview(prev => !prev);
               setPreviewManuallyToggled(true);
             }}
-            className="mt-2"
+            className="mt-1"
           >
             {showPreview ? 'Hide Preview' : 'Show Preview'}
           </Button>

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -160,7 +160,7 @@ const View: React.FC = () => {
 
   if (message && (passcodeVerified || !needsPasscode)) {
     return (
-      <div className="flex min-h-[100dvh] items-center justify-start bg-neutral-50 px-4 pb-8 pt-16 dark:bg-neutral-900 sm:py-12">
+      <div className="flex min-h-[100dvh] items-center justify-start bg-neutral-50 px-4 py-8 dark:bg-neutral-900 sm:py-12">
         <MessageViewer
           message={message}
           onRecordReaction={async () => {}} // Changed to an async no-op function

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -120,7 +120,7 @@ const View: React.FC = () => {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900">
         <LoadingSpinner size="lg" />
         <p className="mt-4 text-neutral-600 dark:text-neutral-300">Loading message...</p>
       </div>
@@ -129,7 +129,7 @@ const View: React.FC = () => {
 
   if (error) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
         <div className="max-w-md text-center">
           <h2 className="mt-2 text-2xl font-bold text-neutral-900 dark:text-white">
             {error === MESSAGE_ERRORS.NOT_FOUND
@@ -152,7 +152,7 @@ const View: React.FC = () => {
 
   if (needsPasscode && !passcodeVerified) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
+      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
         <PasscodeEntry onSubmitPasscode={handleSubmitPasscode} />
       </div>
     );
@@ -160,7 +160,7 @@ const View: React.FC = () => {
 
   if (message && (passcodeVerified || !needsPasscode)) {
     return (
-      <div className="flex min-h-screen items-center justify-start bg-neutral-50 px-4 pb-8 pt-16 dark:bg-neutral-900 sm:py-12">
+      <div className="flex min-h-[100dvh] items-center justify-start bg-neutral-50 px-4 pb-8 pt-16 dark:bg-neutral-900 sm:py-12">
         <MessageViewer
           message={message}
           onRecordReaction={async () => {}} // Changed to an async no-op function
@@ -177,7 +177,7 @@ const View: React.FC = () => {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-neutral-900">
+    <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 dark:bg-neutral-900">
       <div className="text-center">
         <p className="text-neutral-600 dark:text-neutral-300">
           Something went wrong. Please try again later.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -73,6 +73,8 @@ module.exports = {
         fadeIn: 'fadeIn 0.5s ease-out',
         slideUp: 'slideUp 0.5s ease-out',
         'record-glow': 'record-glow 1.2s ease-in-out infinite',
+        'record-glow-md': 'record-glow-md 1.2s ease-in-out infinite',
+        'record-glow-lg': 'record-glow-lg 1.2s ease-in-out infinite',
       },
       keyframes: {
         fadeIn: {
@@ -91,6 +93,26 @@ module.exports = {
           '50%': {
             opacity: '1',
             'box-shadow': '0 0 0 4px rgba(239,68,68,1)',
+          },
+        },
+        'record-glow-md': {
+          '0%, 100%': {
+            opacity: '0.6',
+            'box-shadow': '0 0 0 12px rgba(239,68,68,0.5)',
+          },
+          '50%': {
+            opacity: '1',
+            'box-shadow': '0 0 0 12px rgba(239,68,68,1)',
+          },
+        },
+        'record-glow-lg': {
+          '0%, 100%': {
+            opacity: '0.6',
+            'box-shadow': '0 0 0 20px rgba(239,68,68,0.5)',
+          },
+          '50%': {
+            opacity: '1',
+            'box-shadow': '0 0 0 20px rgba(239,68,68,1)',
           },
         },
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -68,10 +68,6 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
-      borderWidth: {
-        'record-mobile': '1.5vw',
-        'record-desktop': '0.75vw',
-      },
       // Add animations
       animation: {
         fadeIn: 'fadeIn 0.5s ease-out',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -68,13 +68,17 @@ module.exports = {
       fontFamily: {
         sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
+      borderWidth: {
+        'record-mobile': '3vw',
+        'record-desktop': '1.5vw',
+      },
       // Add animations
       animation: {
         fadeIn: 'fadeIn 0.5s ease-out',
         slideUp: 'slideUp 0.5s ease-out',
-        'record-glow': 'record-glow 1.2s ease-in-out infinite',
-        'record-glow-md': 'record-glow-md 1.2s ease-in-out infinite',
-        'record-glow-lg': 'record-glow-lg 1.2s ease-in-out infinite',
+        'record-glow': 'record-glow 2s ease-in-out infinite',
+        'record-glow-md': 'record-glow-md 2s ease-in-out infinite',
+        'record-glow-lg': 'record-glow-lg 2s ease-in-out infinite',
       },
       keyframes: {
         fadeIn: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   darkMode: 'class',
   theme: {
     extend: {
@@ -67,45 +64,37 @@ module.exports = {
         error: '#EF4444',
         warning: '#F59E0B',
         info: '#3B82F6',
+      },
+      fontFamily: {
+        sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+      // Add animations
+      animation: {
+        fadeIn: 'fadeIn 0.5s ease-out',
+        slideUp: 'slideUp 0.5s ease-out',
+        'record-glow': 'record-glow 1.2s ease-in-out infinite',
+      },
+      keyframes: {
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
         },
-        fontFamily: {
-          sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        slideUp: {
+          '0%': { opacity: '0', transform: 'translateY(20px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
         },
-        // Add animations
-        animation: {
-          fadeIn: 'fadeIn 0.5s ease-out',
-          slideUp: 'slideUp 0.5s ease-out',
-        },
-        keyframes: {
-          fadeIn: {
-            '0%': { opacity: '0' },
-            '100%': { opacity: '1' },
+        'record-glow': {
+          '0%, 100%': {
+            opacity: '0.6',
+            'box-shadow': '0 0 0 4px rgba(239,68,68,0.5)',
           },
-          slideUp: {
-            '0%': { opacity: '0', transform: 'translateY(20px)' },
-            '100%': { opacity: '1', transform: 'translateY(0)' },
+          '50%': {
+            opacity: '1',
+            'box-shadow': '0 0 0 4px rgba(239,68,68,1)',
           },
-          'grow-width': { // Top and Bottom
-            '0%': { width: '0%' },
-            '100%': { width: '100%' },
-          },
-          'grow-height': { // Right and Left
-            '0%': { height: '0%' },
-            '100%': { height: '100%' },
-          },
-        },
-        animation: { // Ensure this is correctly placed within extend: {}
-          fadeIn: 'fadeIn 0.5s ease-out',
-          slideUp: 'slideUp 0.5s ease-out',
-          'snake-border-top': 'grow-width',
-          'snake-border-right': 'grow-height',
-          'snake-border-bottom': 'grow-width',
-          'snake-border-left': 'grow-height',
         },
       },
     },
-  plugins: [
-    require('@tailwindcss/forms'),
-    require('@tailwindcss/aspect-ratio'),
-  ],
+  },
+  plugins: [require('@tailwindcss/forms'), require('@tailwindcss/aspect-ratio')],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,8 +69,8 @@ module.exports = {
         sans: ['Inter var', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
       borderWidth: {
-        'record-mobile': '3vw',
-        'record-desktop': '1.5vw',
+        'record-mobile': '1.5vw',
+        'record-desktop': '0.75vw',
       },
       // Add animations
       animation: {
@@ -92,31 +92,31 @@ module.exports = {
         'record-glow': {
           '0%, 100%': {
             opacity: '0.6',
-            'box-shadow': '0 0 0 4px rgba(239,68,68,0.5)',
+            'box-shadow': 'inset 0 0 0 4px rgba(239,68,68,0.5)',
           },
           '50%': {
             opacity: '1',
-            'box-shadow': '0 0 0 4px rgba(239,68,68,1)',
+            'box-shadow': 'inset 0 0 0 4px rgba(239,68,68,1)',
           },
         },
         'record-glow-md': {
           '0%, 100%': {
             opacity: '0.6',
-            'box-shadow': '0 0 0 12px rgba(239,68,68,0.5)',
+            'box-shadow': 'inset 0 0 0 8px rgba(239,68,68,0.5)',
           },
           '50%': {
             opacity: '1',
-            'box-shadow': '0 0 0 12px rgba(239,68,68,1)',
+            'box-shadow': 'inset 0 0 0 8px rgba(239,68,68,1)',
           },
         },
         'record-glow-lg': {
           '0%, 100%': {
             opacity: '0.6',
-            'box-shadow': '0 0 0 20px rgba(239,68,68,0.5)',
+            'box-shadow': 'inset 0 0 0 15px rgba(239,68,68,0.5)',
           },
           '50%': {
             opacity: '1',
-            'box-shadow': '0 0 0 20px rgba(239,68,68,1)',
+            'box-shadow': 'inset 0 0 0 15px rgba(239,68,68,1)',
           },
         },
       },


### PR DESCRIPTION
## Summary
- animate a subtle `record-glow` effect via Tailwind config
- simplify `RecordingBorder` to use the new pulsing border instead of the snake animation

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684c1b95e68c8324ae76cb5e13cdc3e7