### PR TITLE
Add configurable Cloudinary logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ reactlyve-frontend/
    npm install
    ```
 
-3. Create a `.env` file in the root directory with the following variable:
+3. Create a `.env` file in the root directory with the following variables:
 
    ```
    VITE_API_URL=http://localhost:8000/api
+   VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
+   `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
 
 4. Start the development server:
 

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -1,7 +1,10 @@
 // src/utils/mediaHelpers.ts
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = 'f_auto,q_auto/l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10';
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = 'w_1280,c_limit,q_auto,f_auto/l_Reactlyve_Logo_bi78md/fl_layer_apply,w_0.3,g_south_east,x_10,y_10';
+const CLOUDINARY_LOGO_ID =
+  import.meta.env.VITE_CLOUDINARY_LOGO_ID || 'Reactlyve_Logo_bi78md';
+
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions


### PR DESCRIPTION
## Summary
- make Cloudinary overlay ID configurable with `VITE_CLOUDINARY_LOGO_ID`
- document new `.env` variable

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ce527ac5083249431409fbfba15a9