### PR TITLE
Fix watermark size

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ reactlyve-frontend/
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
-   `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
+   `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media. The
+   overlay width is fixed at 150&nbsp;px so the watermark remains a consistent size
+   across different resolutions.
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ reactlyve-frontend/
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
-   `VITE_CLOUDINARY_LOGO_SCALE` sets the watermark width as a fraction of the asset width (default: 0.15),
+   `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.15),
    producing consistent results across different resolutions.
 
 4. Start the development server:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ reactlyve-frontend/
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
   `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.3),
-   producing consistent results across different resolutions.
+   producing consistent results across different resolutions. Message previews skip applying a new transformation when the URL already contains the overlay,
+   so updates to the environment variable are reflected once new assets are generated.
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -81,12 +81,14 @@ reactlyve-frontend/
    ```
    VITE_API_URL=http://localhost:8000/api
    VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
+   # Optional: adjust the watermark width (default 200px)
+   VITE_CLOUDINARY_LOGO_WIDTH=200
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
-   `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media. The
-   overlay width is fixed at 150&nbsp;px so the watermark remains a consistent size
-   across different resolutions.
+   `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
+   `VITE_CLOUDINARY_LOGO_WIDTH` sets the watermark width in pixels (default: 200),
+   so you can tweak the size if it appears too small or large on your assets.
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ reactlyve-frontend/
    ```
    VITE_API_URL=http://localhost:8000/api
    VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
-  # Optional: adjust the watermark scale (default 0.2 = 20% of asset width)
-  VITE_CLOUDINARY_LOGO_SCALE=0.2
+  # Optional: adjust the watermark scale (default 0.3 = 30% of asset width)
+  VITE_CLOUDINARY_LOGO_SCALE=0.3
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
-  `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.2),
+  `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.3),
    producing consistent results across different resolutions.
 
 4. Start the development server:

--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ reactlyve-frontend/
    ```
    VITE_API_URL=http://localhost:8000/api
    VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
-   # Optional: adjust the watermark width (default 200px)
-   VITE_CLOUDINARY_LOGO_WIDTH=200
+   # Optional: adjust the watermark scale (default 0.15 = 15% of asset width)
+   VITE_CLOUDINARY_LOGO_SCALE=0.15
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
-   `VITE_CLOUDINARY_LOGO_WIDTH` sets the watermark width in pixels (default: 200),
-   so you can tweak the size if it appears too small or large on your assets.
+   `VITE_CLOUDINARY_LOGO_SCALE` sets the watermark width as a fraction of the asset width (default: 0.15),
+   producing consistent results across different resolutions.
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -81,15 +81,12 @@ reactlyve-frontend/
    ```
    VITE_API_URL=http://localhost:8000/api
    VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
-  # Optional: adjust the watermark scale (default 0.3 = 30% of asset width)
   VITE_CLOUDINARY_LOGO_SCALE=0.3
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
-  `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.3),
-   producing consistent results across different resolutions. Restart the dev server after updating this variable so the new scale is applied.
-   Message previews skip applying a new transformation when the URL already contains the overlay, so the environment change affects only newly generated assets.
+  `VITE_CLOUDINARY_LOGO_SCALE` sets the watermark width relative to the asset (default: 0.3).
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ reactlyve-frontend/
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
   `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.3),
-   producing consistent results across different resolutions. Message previews skip applying a new transformation when the URL already contains the overlay,
-   so updates to the environment variable are reflected once new assets are generated.
+   producing consistent results across different resolutions. Restart the dev server after updating this variable so the new scale is applied.
+   Message previews skip applying a new transformation when the URL already contains the overlay, so the environment change affects only newly generated assets.
 
 4. Start the development server:
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,13 @@ reactlyve-frontend/
    ```
    VITE_API_URL=http://localhost:8000/api
    VITE_CLOUDINARY_LOGO_ID=Reactlyve_Logo_bi78md
-   # Optional: adjust the watermark scale (default 0.15 = 15% of asset width)
-   VITE_CLOUDINARY_LOGO_SCALE=0.15
+  # Optional: adjust the watermark scale (default 0.2 = 20% of asset width)
+  VITE_CLOUDINARY_LOGO_SCALE=0.2
    ```
 
    If `VITE_API_URL` is omitted, the app defaults to `https://api.reactlyve.com/api`.
    `VITE_CLOUDINARY_LOGO_ID` controls the Cloudinary overlay used in generated media.
-   `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.15),
+  `VITE_CLOUDINARY_LOGO_SCALE` defines the overlay width relative to the underlying asset using Cloudinary's `fl_relative` flag (default: 0.2),
    producing consistent results across different resolutions.
 
 4. Start the development server:

--- a/src/components/dashboard/MessageDetails.tsx
+++ b/src/components/dashboard/MessageDetails.tsx
@@ -4,6 +4,7 @@ import ReactionViewer from './ReactionViewer';
 import { formatDate } from '../../utils/formatters';
 import Button from '../common/Button';
 import { normalizeMessage } from '../../utils/normalizeKeys';
+import { getTransformedCloudinaryUrl } from '../../utils/mediaHelpers';
 import Modal from '../common/Modal';
 import Input from '../common/Input';
 import { messagesApi } from '../../services/api';
@@ -21,6 +22,24 @@ const MessageDetails: React.FC<MessageDetailsProps> = ({ message, onDeleteReacti
   }, [message]);
   const videoRef = useRef<HTMLVideoElement>(null);
   const [showQrCode, setShowQrCode] = useState(false);
+
+  const transformedImgUrl = useMemo(() => {
+    return normalizedMessage.imageUrl
+      ? getTransformedCloudinaryUrl(
+          normalizedMessage.imageUrl,
+          normalizedMessage.fileSizeInBytes || 0
+        )
+      : '';
+  }, [normalizedMessage.imageUrl, normalizedMessage.fileSizeInBytes]);
+
+  const transformedVideoUrl = useMemo(() => {
+    return normalizedMessage.videoUrl
+      ? getTransformedCloudinaryUrl(
+          normalizedMessage.videoUrl,
+          normalizedMessage.fileSizeInBytes || 0
+        )
+      : '';
+  }, [normalizedMessage.videoUrl, normalizedMessage.fileSizeInBytes]);
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [reactionLengthInput, setReactionLengthInput] = useState(normalizedMessage.reaction_length || 10);
@@ -119,10 +138,21 @@ const MessageDetails: React.FC<MessageDetailsProps> = ({ message, onDeleteReacti
 
       {/* Media Preview */}
       {normalizedMessage.imageUrl && normalizedMessage.mediaType === 'image' && (
-        <img src={normalizedMessage.imageUrl} alt="Message media" className="rounded-md mb-4 w-full" />
+        <img
+          src={transformedImgUrl || normalizedMessage.imageUrl}
+          alt="Message media"
+          className="rounded-md mb-4 w-full"
+        />
       )}
       {normalizedMessage.videoUrl && normalizedMessage.mediaType === 'video' && (
-        <video ref={videoRef} src={normalizedMessage.videoUrl} controls autoPlay playsInline className="rounded-md mb-4 w-full" />
+        <video
+          ref={videoRef}
+          src={transformedVideoUrl || normalizedMessage.videoUrl}
+          controls
+          autoPlay
+          playsInline
+          className="rounded-md mb-4 w-full"
+        />
       )}
 
       {/* Shareable Link & Options */}

--- a/src/components/dashboard/MessageDetails.tsx
+++ b/src/components/dashboard/MessageDetails.tsx
@@ -4,7 +4,6 @@ import ReactionViewer from './ReactionViewer';
 import { formatDate } from '../../utils/formatters';
 import Button from '../common/Button';
 import { normalizeMessage } from '../../utils/normalizeKeys';
-import { getTransformedCloudinaryUrl } from '../../utils/mediaHelpers';
 import Modal from '../common/Modal';
 import Input from '../common/Input';
 import { messagesApi } from '../../services/api';
@@ -23,23 +22,6 @@ const MessageDetails: React.FC<MessageDetailsProps> = ({ message, onDeleteReacti
   const videoRef = useRef<HTMLVideoElement>(null);
   const [showQrCode, setShowQrCode] = useState(false);
 
-  const transformedImgUrl = useMemo(() => {
-    return normalizedMessage.imageUrl
-      ? getTransformedCloudinaryUrl(
-          normalizedMessage.imageUrl,
-          normalizedMessage.fileSizeInBytes || 0
-        )
-      : '';
-  }, [normalizedMessage.imageUrl, normalizedMessage.fileSizeInBytes]);
-
-  const transformedVideoUrl = useMemo(() => {
-    return normalizedMessage.videoUrl
-      ? getTransformedCloudinaryUrl(
-          normalizedMessage.videoUrl,
-          normalizedMessage.fileSizeInBytes || 0
-        )
-      : '';
-  }, [normalizedMessage.videoUrl, normalizedMessage.fileSizeInBytes]);
 
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [reactionLengthInput, setReactionLengthInput] = useState(normalizedMessage.reaction_length || 10);
@@ -138,16 +120,12 @@ const MessageDetails: React.FC<MessageDetailsProps> = ({ message, onDeleteReacti
 
       {/* Media Preview */}
       {normalizedMessage.imageUrl && normalizedMessage.mediaType === 'image' && (
-        <img
-          src={transformedImgUrl || normalizedMessage.imageUrl}
-          alt="Message media"
-          className="rounded-md mb-4 w-full"
-        />
+        <img src={normalizedMessage.imageUrl} alt="Message media" className="rounded-md mb-4 w-full" />
       )}
       {normalizedMessage.videoUrl && normalizedMessage.mediaType === 'video' && (
         <video
           ref={videoRef}
-          src={transformedVideoUrl || normalizedMessage.videoUrl}
+          src={normalizedMessage.videoUrl}
           controls
           autoPlay
           playsInline

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -5,9 +5,9 @@ const CLOUDINARY_LOGO_ID =
 
 // Watermark scale can be customized via the environment. Using a relative
 // width keeps the overlay proportional to the underlying media. Defaults to
-// `0.2` (20% of the asset width).
+// `0.3` (30% of the asset width).
 const CLOUDINARY_LOGO_SCALE =
-  import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.2';
+  import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.3';
 
 export const SMALL_FILE_TRANSFORM_WITH_OVERLAY =
   `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -5,9 +5,9 @@ const CLOUDINARY_LOGO_ID =
 
 // Watermark scale can be customized via the environment. Using a relative
 // width keeps the overlay proportional to the underlying media. Defaults to
-// `0.15` (15% of the asset width).
+// `0.2` (20% of the asset width).
 const CLOUDINARY_LOGO_SCALE =
-  import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.15';
+  import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.2';
 
 export const SMALL_FILE_TRANSFORM_WITH_OVERLAY =
   `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -258,13 +258,21 @@ export const getTransformedCloudinaryUrl = (
   originalUrl: string,
   fileSizeInBytes: number
 ): string => {
+  const uploadMarker = '/upload/';
+  const partsCheck = originalUrl.split(uploadMarker);
+  if (partsCheck.length === 2) {
+    const [, pathAfterUploadCheck] = partsCheck;
+    if (pathAfterUploadCheck.includes(`l_${CLOUDINARY_LOGO_ID}`)) {
+      // URL already has our overlay transformation applied; return as-is
+      return originalUrl;
+    }
+  }
   const tenMBInBytes = 10 * 1024 * 1024; // 10MB threshold
 
   const transformationString = fileSizeInBytes < tenMBInBytes
     ? SMALL_FILE_TRANSFORM_WITH_OVERLAY
     : LARGE_FILE_TRANSFORM_WITH_OVERLAY;
 
-  const uploadMarker = '/upload/';
   const parts = originalUrl.split(uploadMarker);
 
   if (parts.length === 2) {

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -3,8 +3,11 @@
 const CLOUDINARY_LOGO_ID =
   import.meta.env.VITE_CLOUDINARY_LOGO_ID || 'Reactlyve_Logo_bi78md';
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_0.3,g_south_east,x_10,y_10`;
+// Use a fixed overlay width so the watermark size remains consistent
+// regardless of the underlying media resolution.
+// "w_150" sets the overlay to 150px wide.
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_150,g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_150,g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -4,16 +4,12 @@ const CLOUDINARY_LOGO_ID =
   import.meta.env.VITE_CLOUDINARY_LOGO_ID || 'Reactlyve_Logo_bi78md';
 
 // Watermark scale can be customized via the environment. Using a relative
-// width keeps the overlay proportional to the underlying media. Defaults to
-// `0.3` (30% of the asset width). Reading the value in a function ensures the
-// latest environment configuration is used even after hot reloads.
-const getCloudinaryLogoScale = (): string =>
+// width keeps the overlay proportional to the underlying media.
+const CLOUDINARY_LOGO_SCALE =
   import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.3';
 
-export const getSmallFileTransformWithOverlay = (): string =>
-  `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${getCloudinaryLogoScale()},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
-export const getLargeFileTransformWithOverlay = (): string =>
-  `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID},w_${getCloudinaryLogoScale()},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions
@@ -259,20 +255,13 @@ export const getTransformedCloudinaryUrl = (
   originalUrl: string,
   fileSizeInBytes: number
 ): string => {
-  const uploadMarker = '/upload/';
-  const partsCheck = originalUrl.split(uploadMarker);
-  if (partsCheck.length === 2) {
-    const [, pathAfterUploadCheck] = partsCheck;
-    if (pathAfterUploadCheck.includes(`l_${CLOUDINARY_LOGO_ID}`)) {
-      // URL already has our overlay transformation applied; return as-is
-      return originalUrl;
-    }
-  }
   const tenMBInBytes = 10 * 1024 * 1024; // 10MB threshold
 
+  const uploadMarker = '/upload/';
+
   const transformationString = fileSizeInBytes < tenMBInBytes
-    ? getSmallFileTransformWithOverlay()
-    : getLargeFileTransformWithOverlay();
+    ? SMALL_FILE_TRANSFORM_WITH_OVERLAY
+    : LARGE_FILE_TRANSFORM_WITH_OVERLAY;
 
   const parts = originalUrl.split(uploadMarker);
 

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -3,11 +3,14 @@
 const CLOUDINARY_LOGO_ID =
   import.meta.env.VITE_CLOUDINARY_LOGO_ID || 'Reactlyve_Logo_bi78md';
 
-// Use a fixed overlay width so the watermark size remains consistent
-// regardless of the underlying media resolution.
-// "w_150" sets the overlay to 150px wide.
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_150,g_south_east,x_10,y_10`;
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_150,g_south_east,x_10,y_10`;
+// Overlay width can be customized via the environment. Defaults to 200px so the
+// watermark isn't too tiny on large assets while remaining reasonable on small
+// files.
+const CLOUDINARY_LOGO_WIDTH =
+  import.meta.env.VITE_CLOUDINARY_LOGO_WIDTH || '200';
+
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_WIDTH},g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_WIDTH},g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -9,8 +9,10 @@ const CLOUDINARY_LOGO_ID =
 const CLOUDINARY_LOGO_SCALE =
   import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.15';
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_SCALE},g_south_east,x_10,y_10`;
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_SCALE},g_south_east,x_10,y_10`;
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY =
+  `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY =
+  `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -3,14 +3,14 @@
 const CLOUDINARY_LOGO_ID =
   import.meta.env.VITE_CLOUDINARY_LOGO_ID || 'Reactlyve_Logo_bi78md';
 
-// Overlay width can be customized via the environment. Defaults to 200px so the
-// watermark isn't too tiny on large assets while remaining reasonable on small
-// files.
-const CLOUDINARY_LOGO_WIDTH =
-  import.meta.env.VITE_CLOUDINARY_LOGO_WIDTH || '200';
+// Watermark scale can be customized via the environment. Using a relative
+// width keeps the overlay proportional to the underlying media. Defaults to
+// `0.15` (15% of the asset width).
+const CLOUDINARY_LOGO_SCALE =
+  import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.15';
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_WIDTH},g_south_east,x_10,y_10`;
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_WIDTH},g_south_east,x_10,y_10`;
+export const SMALL_FILE_TRANSFORM_WITH_OVERLAY = `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_SCALE},g_south_east,x_10,y_10`;
+export const LARGE_FILE_TRANSFORM_WITH_OVERLAY = `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID}/fl_layer_apply,w_${CLOUDINARY_LOGO_SCALE},g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions

--- a/src/utils/mediaHelpers.ts
+++ b/src/utils/mediaHelpers.ts
@@ -5,14 +5,15 @@ const CLOUDINARY_LOGO_ID =
 
 // Watermark scale can be customized via the environment. Using a relative
 // width keeps the overlay proportional to the underlying media. Defaults to
-// `0.3` (30% of the asset width).
-const CLOUDINARY_LOGO_SCALE =
+// `0.3` (30% of the asset width). Reading the value in a function ensures the
+// latest environment configuration is used even after hot reloads.
+const getCloudinaryLogoScale = (): string =>
   import.meta.env.VITE_CLOUDINARY_LOGO_SCALE || '0.3';
 
-export const SMALL_FILE_TRANSFORM_WITH_OVERLAY =
-  `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
-export const LARGE_FILE_TRANSFORM_WITH_OVERLAY =
-  `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID},w_${CLOUDINARY_LOGO_SCALE},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
+export const getSmallFileTransformWithOverlay = (): string =>
+  `f_auto,q_auto/l_${CLOUDINARY_LOGO_ID},w_${getCloudinaryLogoScale()},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
+export const getLargeFileTransformWithOverlay = (): string =>
+  `w_1280,c_limit,q_auto,f_auto/l_${CLOUDINARY_LOGO_ID},w_${getCloudinaryLogoScale()},fl_relative/fl_layer_apply,g_south_east,x_10,y_10`;
 
 /**
  * Request camera and microphone permissions
@@ -270,8 +271,8 @@ export const getTransformedCloudinaryUrl = (
   const tenMBInBytes = 10 * 1024 * 1024; // 10MB threshold
 
   const transformationString = fileSizeInBytes < tenMBInBytes
-    ? SMALL_FILE_TRANSFORM_WITH_OVERLAY
-    : LARGE_FILE_TRANSFORM_WITH_OVERLAY;
+    ? getSmallFileTransformWithOverlay()
+    : getLargeFileTransformWithOverlay();
 
   const parts = originalUrl.split(uploadMarker);
 


### PR DESCRIPTION
## Summary
- maintain fixed 150px width for the Cloudinary overlay
- note overlay width in README

## Testing
- `npm test`
- `npm run lint` *(fails: numerous existing warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cf357524c8324b99f630482b72d12