### PR TITLE
Add one-time link management

### DIFF
--- a/src/components/constants/apiRoutes.ts
+++ b/src/components/constants/apiRoutes.ts
@@ -15,9 +15,15 @@ export const MESSAGE_ROUTES = {
   GET_ALL: `${API_BASE_URL}/messages`,
   GET_BY_ID: (id: string) => `${API_BASE_URL}/messages/${id}`,
   DELETE: (id: string) => `${API_BASE_URL}/messages/${id}/delete`,
-  VIEW: (id: string) => `${API_BASE_URL}/messages/shared/${id}`,
+  VIEW: (id: string) => `${API_BASE_URL}/messages/view/${id}`,
   VERIFY_PASSCODE: (id: string) => `${API_BASE_URL}/messages/${id}/verify-passcode`,
   SHARED: (id: string) => `${API_BASE_URL}/messages/shared/${id}`,
+};
+
+export const MESSAGE_LINK_ROUTES = {
+  CREATE: (messageId: string) => `${API_BASE_URL}/messages/${messageId}/links`,
+  LIST: (messageId: string) => `${API_BASE_URL}/messages/${messageId}/links`,
+  DELETE: (linkId: string) => `${API_BASE_URL}/messages/links/${linkId}`,
 };
 
 // Reaction Routes

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -23,7 +23,7 @@ interface LinkItem {
   updatedAt: string;
 }
 
-const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) => {
+const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId, passcode }) => {
   const [links, setLinks] = useState<LinkItem[]>([]);
   const [liveOneTime, setLiveOneTime] = useState(0);
   const [expiredOneTime, setExpiredOneTime] = useState(0);
@@ -81,6 +81,23 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
     toast.success('Copied to clipboard');
   };
 
+  const handleShareLink = (url: string) => {
+    if (navigator.share) {
+      let shareText;
+      if (passcode) {
+        shareText = `Check out my surprise message!\nPasscode: ${passcode}\n`;
+      } else {
+        shareText = 'Check out my surprise message!\n\n';
+      }
+
+      navigator
+        .share({ title: 'Reactlyve Message', text: shareText, url })
+        .catch(() => copyToClipboard(url));
+    } else {
+      copyToClipboard(url);
+    }
+  };
+
   const baseUrl = window.location.origin;
 
   return (
@@ -119,7 +136,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                       <Button
                         size="sm"
                         className="bg-secondary-600 text-white hover:bg-secondary-700"
-                        onClick={() => (navigator.share ? navigator.share({ url }) : copyToClipboard(url))}
+                        onClick={() => handleShareLink(url)}
                         title="Share Link"
                       >
                         <Share2Icon size={16} />

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -26,7 +26,6 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
   const [links, setLinks] = useState<LinkItem[]>([]);
   const [liveOneTime, setLiveOneTime] = useState(0);
   const [expiredOneTime, setExpiredOneTime] = useState(0);
-  const [newOnetime, setNewOnetime] = useState(false);
   const [loading, setLoading] = useState(false);
   const [creating, setCreating] = useState(false);
 
@@ -53,10 +52,10 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
-  const handleCreate = async () => {
+  const handleCreate = async (onetime: boolean) => {
     setCreating(true);
     try {
-      await messageLinksApi.create(messageId, newOnetime);
+      await messageLinksApi.create(messageId, onetime);
       toast.success('Link created');
       await fetchLinks();
     } catch (err) {
@@ -90,18 +89,11 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
           Live one-time links: {liveOneTime} • Viewed: {expiredOneTime}
         </p>
         <div className="flex items-center space-x-2">
-          <input
-            type="checkbox"
-            id="new-onetime"
-            checked={newOnetime}
-            onChange={(e) => setNewOnetime(e.target.checked)}
-            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-          />
-          <label htmlFor="new-onetime" className="text-sm text-neutral-700 dark:text-neutral-300">
-            One-time link
-          </label>
-          <Button onClick={handleCreate} isLoading={creating} size="sm">
-            Create Link
+          <Button onClick={() => handleCreate(false)} isLoading={creating} size="sm">
+            Create Reusable Link
+          </Button>
+          <Button onClick={() => handleCreate(true)} isLoading={creating} size="sm">
+            Create One Time Link
           </Button>
         </div>
         {loading ? (

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -114,18 +114,18 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                   <div className="flex items-center justify-between">
                     <span className="text-sm break-all">{url}</span>
                     <div className="flex space-x-2">
-                      <Button size="xs" variant="outline" onClick={() => copyToClipboard(url)}>
+                      <Button size="sm" variant="outline" onClick={() => copyToClipboard(url)}>
                         Copy
                       </Button>
                       <Button
-                        size="xs"
+                        size="sm"
                         variant="outline"
                         onClick={() => navigator.share ? navigator.share({ url }) : copyToClipboard(url)}
                       >
                         Share
                       </Button>
                       <Button
-                        size="xs"
+                        size="sm"
                         variant="outline"
                         onClick={() => {
                           const el = document.createElement('div');
@@ -144,7 +144,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                       >
                         QR
                       </Button>
-                      <Button size="xs" variant="danger" onClick={() => handleDelete(link.id)}>
+                      <Button size="sm" variant="danger" onClick={() => handleDelete(link.id)}>
                         Delete
                       </Button>
                     </div>

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -117,7 +117,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                     <div className="flex space-x-2">
                       <Button
                         size="sm"
-                        variant="outline"
+                        className="bg-blue-600 text-white hover:bg-blue-700"
                         onClick={() => copyToClipboard(url)}
                         title="Copy Link"
                       >
@@ -125,7 +125,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                       </Button>
                       <Button
                         size="sm"
-                        variant="outline"
+                        className="bg-secondary-600 text-white hover:bg-secondary-700"
                         onClick={() => (navigator.share ? navigator.share({ url }) : copyToClipboard(url))}
                         title="Share Link"
                       >
@@ -133,7 +133,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                       </Button>
                       <Button
                         size="sm"
-                        variant="outline"
+                        className="bg-green-600 text-white hover:bg-green-700"
                         onClick={() => {
                           const el = document.createElement('div');
                           document.body.appendChild(el);

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -17,7 +17,8 @@ interface LinksModalProps {
 interface LinkItem {
   id: string;
   onetime: boolean;
-  viewed: boolean;
+  viewed: boolean; // deprecated, use linkViewed
+  linkViewed?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -162,7 +163,9 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                     </div>
                   </div>
                   <p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1">
-                    {link.onetime ? (link.viewed ? 'Viewed' : 'Live') : 'Reusable'}
+                    {link.onetime
+                      ? (link.linkViewed ?? link.viewed ? 'Viewed' : 'Live')
+                      : 'Reusable'}
                   </p>
                 </li>
               );

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -5,6 +5,7 @@ import Button from '../common/Button';
 import { messageLinksApi } from '../../services/api';
 import { QRCodeSVG } from 'qrcode.react';
 import toast from 'react-hot-toast';
+import { CopyIcon, Share2Icon } from 'lucide-react';
 
 interface LinksModalProps {
   isOpen: boolean;
@@ -114,15 +115,21 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                   <div className="flex items-center justify-between">
                     <span className="text-sm break-all">{url}</span>
                     <div className="flex space-x-2">
-                      <Button size="sm" variant="outline" onClick={() => copyToClipboard(url)}>
-                        Copy
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => copyToClipboard(url)}
+                        title="Copy Link"
+                      >
+                        <CopyIcon size={16} />
                       </Button>
                       <Button
                         size="sm"
                         variant="outline"
-                        onClick={() => navigator.share ? navigator.share({ url }) : copyToClipboard(url)}
+                        onClick={() => (navigator.share ? navigator.share({ url }) : copyToClipboard(url))}
+                        title="Share Link"
                       >
-                        Share
+                        <Share2Icon size={16} />
                       </Button>
                       <Button
                         size="sm"
@@ -141,8 +148,21 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) =
                           // @ts-ignore
                           ReactDOM.render(qr, el);
                         }}
+                        title="Show QR"
                       >
-                        QR
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className="h-4 w-4"
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z"
+                            clipRule="evenodd"
+                          />
+                          <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z" />
+                        </svg>
                       </Button>
                       <Button size="sm" variant="danger" onClick={() => handleDelete(link.id)}>
                         Delete

--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
+import Modal from '../common/Modal';
+import Button from '../common/Button';
+import { messageLinksApi } from '../../services/api';
+import { QRCodeSVG } from 'qrcode.react';
+import toast from 'react-hot-toast';
+
+interface LinksModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  messageId: string;
+  passcode?: string | null;
+}
+
+interface LinkItem {
+  id: string;
+  onetime: boolean;
+  viewed: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId }) => {
+  const [links, setLinks] = useState<LinkItem[]>([]);
+  const [liveOneTime, setLiveOneTime] = useState(0);
+  const [expiredOneTime, setExpiredOneTime] = useState(0);
+  const [newOnetime, setNewOnetime] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+
+  const fetchLinks = async () => {
+    setLoading(true);
+    try {
+      const res = await messageLinksApi.list(messageId);
+      setLinks(res.data.links || []);
+      if (res.data.stats) {
+        setLiveOneTime(res.data.stats.liveOneTime || 0);
+        setExpiredOneTime(res.data.stats.expiredOneTime || 0);
+      }
+    } catch (err) {
+      toast.error('Failed to load links');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchLinks();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    try {
+      await messageLinksApi.create(messageId, newOnetime);
+      toast.success('Link created');
+      await fetchLinks();
+    } catch (err) {
+      toast.error('Failed to create link');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleDelete = async (linkId: string) => {
+    try {
+      await messageLinksApi.delete(linkId);
+      toast.success('Link deleted');
+      setLinks((prev) => prev.filter((l) => l.id !== linkId));
+    } catch (err) {
+      toast.error('Failed to delete link');
+    }
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+    toast.success('Copied to clipboard');
+  };
+
+  const baseUrl = window.location.origin;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Message Links" size="lg">
+      <div className="space-y-4">
+        <p className="text-sm text-neutral-700 dark:text-neutral-300">
+          Live one-time links: {liveOneTime} • Viewed: {expiredOneTime}
+        </p>
+        <div className="flex items-center space-x-2">
+          <input
+            type="checkbox"
+            id="new-onetime"
+            checked={newOnetime}
+            onChange={(e) => setNewOnetime(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          <label htmlFor="new-onetime" className="text-sm text-neutral-700 dark:text-neutral-300">
+            One-time link
+          </label>
+          <Button onClick={handleCreate} isLoading={creating} size="sm">
+            Create Link
+          </Button>
+        </div>
+        {loading ? (
+          <p>Loading...</p>
+        ) : (
+          <ul className="space-y-3 max-h-80 overflow-y-auto">
+            {links.map((link) => {
+              const url = `${baseUrl}/view/${link.id}`;
+              return (
+                <li key={link.id} className="rounded-md border p-2 flex flex-col">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm break-all">{url}</span>
+                    <div className="flex space-x-2">
+                      <Button size="xs" variant="outline" onClick={() => copyToClipboard(url)}>
+                        Copy
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        onClick={() => navigator.share ? navigator.share({ url }) : copyToClipboard(url)}
+                      >
+                        Share
+                      </Button>
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        onClick={() => {
+                          const el = document.createElement('div');
+                          document.body.appendChild(el);
+                          const remove = () => document.body.removeChild(el);
+                          const qr = (
+                            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={remove}>
+                              <div className="bg-white p-4 rounded" onClick={(e) => e.stopPropagation()}>
+                                <QRCodeSVG value={url} size={200} />
+                              </div>
+                            </div>
+                          );
+                          // @ts-ignore
+                          ReactDOM.render(qr, el);
+                        }}
+                      >
+                        QR
+                      </Button>
+                      <Button size="xs" variant="danger" onClick={() => handleDelete(link.id)}>
+                        Delete
+                      </Button>
+                    </div>
+                  </div>
+                  <p className="text-xs text-neutral-600 dark:text-neutral-400 mt-1">
+                    {link.onetime ? (link.viewed ? 'Viewed' : 'Live') : 'Reusable'}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default LinksModal;

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -295,61 +295,53 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
   }
 
   if (permissionError) {
-    if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
-      // Dedicated UI for Reaction Limit Error
-      return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
-          <div className="card mx-auto max-w-md p-6 text-center"> {/* Ensure 'card' class provides appropriate styling */}
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center"> {/* Removed mt-4 as icon has mb-4 */}
-              Reaction Limit Reached
-            </h3>
+    const renderErrorCard = (title: string, message?: string, showRefresh?: boolean) => (
+      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
+        <div className="card mx-auto max-w-md p-6 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+          </div>
+          <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center">{title}</h3>
+          {message && (
             <div className="mt-4 rounded-md bg-blue-50 p-4 dark:bg-blue-900/30 text-center">
-              <p className="text-sm font-medium text-blue-700 dark:text-blue-300 text-center">
-                {REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER}
-              </p>
+              <p className="text-sm font-medium text-blue-700 dark:text-blue-300 text-center">{message}</p>
             </div>
+          )}
+          {showRefresh && (
             <div className="mt-6 flex justify-center">
               <button
                 onClick={() => window.location.reload()}
-                className="btn btn-primary bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600" // Matched button style from PermissionRequest
+                className="btn btn-primary bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600"
               >
                 Refresh Page
               </button>
             </div>
-          </div>
+          )}
         </div>
-      );
-    } else if (permissionError === MESSAGE_ERRORS.CONTENT_UNAVAILABLE) {
-      return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
-          <div className="card mx-auto max-w-md p-6 text-center">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center">
-              {MESSAGE_ERRORS.CONTENT_UNAVAILABLE}
-            </h3>
-          </div>
-        </div>
-      );
-    } else {
-      // Fallback to PermissionRequest for other errors that might use this state
-      return (
-        <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
-          <PermissionRequest
-            permissionType="both" // This is still hardcoded; might need review later if other errors use this path
-            errorMessage={permissionError}
-          />
-        </div>
-      );
+      </div>
+    );
+
+    if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
+      return renderErrorCard('Reaction Limit Reached', REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER, true);
     }
+    if (permissionError === MESSAGE_ERRORS.CONTENT_UNAVAILABLE) {
+      return renderErrorCard(MESSAGE_ERRORS.CONTENT_UNAVAILABLE);
+    }
+    if (
+      permissionError === MESSAGE_ERRORS.LINK_EXPIRED ||
+      permissionError === MESSAGE_ERRORS.ALREADY_VIEWED ||
+      permissionError.toLowerCase().includes('link expired')
+    ) {
+      return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED);
+    }
+
+    return (
+      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
+        <PermissionRequest permissionType="both" errorMessage={permissionError} />
+      </div>
+    );
   }
 
   const renderMessageContent = () => (

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -368,11 +368,6 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
 
   const renderMessageContent = () => (
     <div className="card w-full max-w-2xl mx-auto animate-slide-up">
-      {message.onetime && (
-        <div className="mb-4 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
-          This link can only be viewed once.
-        </div>
-      )}
       {message.sender && (
         <div className="mb-4 flex items-center">
           <div className="h-10 w-10 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden">

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -24,6 +24,7 @@ interface MessageViewerProps {
   onSendTextReply?: (messageId: string, text: string) => Promise<void>;
   onInitReactionId?: (id: string) => void;
   onLocalRecordingComplete?: () => void;
+  linkId?: string;
 }
 
 const MessageViewer: React.FC<MessageViewerProps> = ({
@@ -34,6 +35,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
   onSendTextReply,
   onInitReactionId,
   onLocalRecordingComplete,
+  linkId,
 }) => {
   const { user } = useAuth();
 
@@ -230,7 +232,12 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     try {
       const currentSessionId = String(sessionId); // Ensure it's a string
       // The console log should use currentSessionId too
-      const res = await reactionsApi.init(message.id, currentSessionId, recipientName || undefined);
+      const res = await reactionsApi.init(
+        message.id,
+        currentSessionId,
+        recipientName || undefined,
+        linkId
+      );
       if (res.data.reactionId) {
         setReactionId(res.data.reactionId);
         onInitReactionId?.(res.data.reactionId); 
@@ -347,6 +354,11 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
 
   const renderMessageContent = () => (
     <div className="card w-full max-w-2xl mx-auto animate-slide-up">
+      {message.onetime && (
+        <div className="mb-4 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
+          This link can only be viewed once.
+        </div>
+      )}
       {message.sender && (
         <div className="mb-4 flex items-center">
           <div className="h-10 w-10 rounded-full bg-neutral-200 dark:bg-neutral-700 overflow-hidden">

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -539,11 +539,6 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
         )}
         {showRecorder && !isNameSubmitted && (
           <div className="mb-4 w-full max-w-md mx-auto">
-            {message.onetime && (
-              <div className="mb-2 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
-                This link can only be viewed once.
-              </div>
-            )}
             {/* Removed isReactionLimitReached conditional message */}
             <label htmlFor="recipientName" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1 text-center">
               Say hello with your name
@@ -557,10 +552,15 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
               className="w-full p-2 border border-neutral-300 rounded-md dark:bg-neutral-700 dark:border-neutral-600 dark:text-white"
               disabled={isNameSubmitted}
             />
+            {message.onetime && (
+              <div className="mt-2 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                This link can only be viewed once.
+              </div>
+            )}
             <button
-              onClick={handleStartReaction} 
+              onClick={handleStartReaction}
               disabled={!recipientName.trim() || isNameSubmitted}
-              className="btn btn-primary w-full mt-2" 
+              className="btn btn-primary w-full mt-2"
               title={undefined} // Removed reaction limit specific title
             >
               Start Reaction

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -331,7 +331,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     </div>
   );
 
-  if (message.onetime && message.viewed) {
+  if (message.onetime && message.linkViewed) {
     return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED);
   }
 

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -523,8 +523,13 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
             />
           </div>
         )}
-        {showRecorder && !isNameSubmitted && ( 
+        {showRecorder && !isNameSubmitted && (
           <div className="mb-4 w-full max-w-md mx-auto">
+            {message.onetime && (
+              <div className="mb-2 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                This link can only be viewed once.
+              </div>
+            )}
             {/* Removed isReactionLimitReached conditional message */}
             <label htmlFor="recipientName" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1 text-center">
               Say hello with your name

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -332,7 +332,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
   );
 
   if (message.onetime && message.linkViewed) {
-    return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED);
+    return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED, true);
   }
 
   if (!passcodeVerified && message.hasPasscode) {
@@ -356,7 +356,7 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
       permissionError === MESSAGE_ERRORS.ALREADY_VIEWED ||
       permissionError.toLowerCase().includes('link expired')
     ) {
-      return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED);
+      return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED, true);
     }
 
     return (

--- a/src/components/recipient/MessageViewer.tsx
+++ b/src/components/recipient/MessageViewer.tsx
@@ -286,6 +286,55 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
     setCountdownComplete(true);
   };
 
+  const renderErrorCard = (
+    title: string,
+    messageText?: string,
+    showRefresh?: boolean
+  ) => (
+    <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
+      <div className="card mx-auto max-w-md p-6 text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 text-yellow-600 dark:text-yellow-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center">{title}</h3>
+        {messageText && (
+          <div className="mt-4 rounded-md bg-blue-50 p-4 text-center dark:bg-blue-900/30">
+            <p className="text-sm font-medium text-blue-700 dark:text-blue-300 text-center">
+              {messageText}
+            </p>
+          </div>
+        )}
+        {showRefresh && (
+          <div className="mt-6 flex justify-center">
+            <button
+              onClick={() => window.location.reload()}
+              className="btn btn-primary bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600"
+            >
+              Refresh Page
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  if (message.onetime && message.viewed) {
+    return renderErrorCard('Link Expired', MESSAGE_ERRORS.LINK_EXPIRED);
+  }
+
   if (!passcodeVerified && message.hasPasscode) {
     return (
       <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900">
@@ -295,33 +344,6 @@ const MessageViewer: React.FC<MessageViewerProps> = ({
   }
 
   if (permissionError) {
-    const renderErrorCard = (title: string, message?: string, showRefresh?: boolean) => (
-      <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
-        <div className="card mx-auto max-w-md p-6 text-center">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900 mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-600 dark:text-yellow-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-            </svg>
-          </div>
-          <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center">{title}</h3>
-          {message && (
-            <div className="mt-4 rounded-md bg-blue-50 p-4 dark:bg-blue-900/30 text-center">
-              <p className="text-sm font-medium text-blue-700 dark:text-blue-300 text-center">{message}</p>
-            </div>
-          )}
-          {showRefresh && (
-            <div className="mt-6 flex justify-center">
-              <button
-                onClick={() => window.location.reload()}
-                className="btn btn-primary bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600"
-              >
-                Refresh Page
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
-    );
 
     if (permissionError === REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER) {
       return renderErrorCard('Reaction Limit Reached', REACTION_ERRORS.REACTION_LIMIT_CONTACT_SENDER, true);

--- a/src/components/sender/LinkGenerator.tsx
+++ b/src/components/sender/LinkGenerator.tsx
@@ -92,6 +92,23 @@ const LinkGenerator: React.FC<LinkGeneratorProps> = ({
     }
   };
 
+  const handleShareSpecificLink = (url: string) => {
+    if (navigator.share) {
+      let shareText;
+      if (hasPasscode && passcode) {
+        shareText = `Check out my surprise message!\nPasscode: ${passcode}\n`;
+      } else {
+        shareText = 'Check out my surprise message!\n\n';
+      }
+
+      navigator
+        .share({ title: 'Reactlyve Message', text: shareText, url })
+        .catch(() => handleCopySpecificLink(url));
+    } else {
+      handleCopySpecificLink(url);
+    }
+  };
+
   // Copy passcode to clipboard
   const handleCopyPasscode = async () => {
     if (passcode) {
@@ -335,7 +352,7 @@ Passcode: ${passcode}
                       <Button
                         size="sm"
                         className="bg-secondary-600 text-white hover:bg-secondary-700"
-                        onClick={() => (navigator.share ? navigator.share({ url }) : handleCopySpecificLink(url))}
+                        onClick={() => handleShareSpecificLink(url)}
                         title="Share Link"
                       >
                         <Share2Icon size={16} />

--- a/src/components/sender/LinkGenerator.tsx
+++ b/src/components/sender/LinkGenerator.tsx
@@ -225,6 +225,17 @@ Passcode: ${passcode}
         </div>
       )}
 
+      {messageId && (
+        <div className="mt-4 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
+          <p className="text-sm text-neutral-700 dark:text-neutral-300">
+            One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
+          </p>
+          <Button size="sm" variant="outline" onClick={() => setIsLinksModalOpen(true)}>
+            Manage Links
+          </Button>
+        </div>
+      )}
+
       {/* Share options */}
       <div className="mt-5 grid grid-cols-1 gap-3 sm:grid-cols-3">
         <Button 
@@ -287,16 +298,6 @@ Passcode: ${passcode}
         </div>
       )}
 
-      {messageId && (
-        <div className="mt-5 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
-          <p className="text-sm text-neutral-700 dark:text-neutral-300">
-            One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-          </p>
-          <Button size="sm" variant="outline" onClick={() => setIsLinksModalOpen(true)}>
-            Manage Links
-          </Button>
-        </div>
-      )}
 
       {/* Create another message button */}
       <div className="mt-6 text-center">

--- a/src/components/sender/LinkGenerator.tsx
+++ b/src/components/sender/LinkGenerator.tsx
@@ -231,7 +231,7 @@ Passcode: ${passcode}
             One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
           </p>
           <Button size="sm" variant="outline" onClick={() => setIsLinksModalOpen(true)}>
-            Manage Links
+            Manage
           </Button>
         </div>
       )}

--- a/src/components/sender/LinkGenerator.tsx
+++ b/src/components/sender/LinkGenerator.tsx
@@ -8,6 +8,7 @@ interface LinkGeneratorProps {
   shareableLink: string;
   hasPasscode: boolean;
   passcode?: string;
+  onetime?: boolean;
   className?: string;
 }
 
@@ -15,6 +16,7 @@ const LinkGenerator: React.FC<LinkGeneratorProps> = ({
   shareableLink,
   hasPasscode,
   passcode,
+  onetime,
   className,
 }) => {
   const [showQrCode, setShowQrCode] = useState(false);
@@ -110,6 +112,11 @@ Passcode: ${passcode}
         <p className="mt-1 text-neutral-600 dark:text-neutral-300">
           Share this link with someone to capture their reaction
         </p>
+        {onetime && (
+          <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+            This link can be viewed only once.
+          </p>
+        )}
       </div>
 
       {/* Shareable link input */}

--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -554,12 +554,15 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
               onBlur={field.onBlur}
               name={field.name}
               ref={field.ref}
-              className="mr-2 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              className="h-4 w-4 rounded border-neutral-300 text-primary-600 focus:ring-primary-600 dark:border-neutral-700 dark:bg-neutral-900 dark:focus:ring-primary-500"
               disabled={isMessageLimitReached}
             />
           )}
         />
-        <label htmlFor="createOneTimeLink" className="text-sm text-neutral-700 dark:text-neutral-300">
+        <label
+          htmlFor="createOneTimeLink"
+          className="ml-2 text-sm font-medium text-neutral-900 dark:text-neutral-100"
+        >
           Create a one-time link
         </label>
       </div>

--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -558,7 +558,11 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
             <input
               type="checkbox"
               id="onetime"
-              {...field}
+              checked={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              name={field.name}
+              ref={field.ref}
               className="mr-2 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
               disabled={isMessageLimitReached}
             />

--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -540,6 +540,30 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
         />
       </div>
 
+      {/* Create first one-time link option */}
+      <div className="flex items-center">
+        <Controller
+          name="createOneTimeLink"
+          control={control}
+          render={({ field }) => (
+            <input
+              type="checkbox"
+              id="createOneTimeLink"
+              checked={field.value}
+              onChange={field.onChange}
+              onBlur={field.onBlur}
+              name={field.name}
+              ref={field.ref}
+              className="mr-2 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              disabled={isMessageLimitReached}
+            />
+          )}
+        />
+        <label htmlFor="createOneTimeLink" className="text-sm text-neutral-700 dark:text-neutral-300">
+          Create a one-time link
+        </label>
+      </div>
+
       {/* Reaction Length Slider */}
       <div>
         <label
@@ -572,30 +596,6 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
         )}
       </div>
 
-      {/* Create first one-time link option */}
-      <div className="flex items-center">
-        <Controller
-          name="createOneTimeLink"
-          control={control}
-          render={({ field }) => (
-            <input
-              type="checkbox"
-              id="createOneTimeLink"
-              checked={field.value}
-              onChange={field.onChange}
-              onBlur={field.onBlur}
-              name={field.name}
-              ref={field.ref}
-              className="mr-2 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-              disabled={isMessageLimitReached}
-            />
-          )}
-        />
-        <label htmlFor="createOneTimeLink" className="text-sm text-neutral-700 dark:text-neutral-300">
-          Create a one-time link
-        </label>
-      </div>
-      
       {/* Submit button */}
       <div className="flex justify-end">
         <Button

--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -255,6 +255,7 @@ const messageSchema = z.object({
     .min(10, VALIDATION_ERRORS.REACTION_LENGTH_MIN)
     .max(30, VALIDATION_ERRORS.REACTION_LENGTH_MAX)
     .default(15),
+  onetime: z.boolean().default(false),
 });
 
 type MessageFormValues = z.infer<typeof messageSchema>;
@@ -275,6 +276,7 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
   const [mediaType, setMediaType] = useState<'image' | 'video' | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [shareableLink, setShareableLink] = useState<string>('');
+  const [shareableOnetime, setShareableOnetime] = useState(false);
   
   // React Hook Form setup
   const {
@@ -291,6 +293,7 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
       hasPasscode: false,
       passcode: '',
       reaction_length: 15,
+      onetime: false,
     },
   });
   
@@ -298,6 +301,7 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
   const hasPasscode = watch('hasPasscode');
   const passcode = watch('passcode');
   const reactionLengthValue = watch('reaction_length');
+  const onetime = watch('onetime');
   
   // Handle media upload
   const handleMediaSelect = useCallback((file: File | null) => {
@@ -357,13 +361,17 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
 
       // Add reaction length
       formData.append('reaction_length', data.reaction_length.toString());
+      formData.append('onetime', data.onetime.toString());
       
       // Call API to create message with FormData
       const response = await messagesApi.createWithFormData(formData);
-      
+
       // Set the shareable link from the response
       if (response.data.shareableLink) {
         setShareableLink(response.data.shareableLink);
+      }
+      if (response.data.onetime !== undefined) {
+        setShareableOnetime(response.data.onetime);
       }
       
       // Show success message
@@ -416,6 +424,7 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
         shareableLink={shareableLink}
         hasPasscode={hasPasscode}
         passcode={passcode}
+        onetime={shareableOnetime}
         className={className}
       />
     );
@@ -538,6 +547,26 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
             {errors.reaction_length.message}
           </p>
         )}
+      </div>
+
+      {/* One-time Link Option */}
+      <div className="flex items-center">
+        <Controller
+          name="onetime"
+          control={control}
+          render={({ field }) => (
+            <input
+              type="checkbox"
+              id="onetime"
+              {...field}
+              className="mr-2 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              disabled={isMessageLimitReached}
+            />
+          )}
+        />
+        <label htmlFor="onetime" className="text-sm text-neutral-700 dark:text-neutral-300">
+          One-time view link
+        </label>
       </div>
       
       {/* Submit button */}

--- a/src/components/sender/MessageForm.tsx
+++ b/src/components/sender/MessageForm.tsx
@@ -433,7 +433,7 @@ const MessageForm: React.FC<MessageFormProps> = ({ className }) => {
     } finally {
       setIsSubmitting(false);
     }
-  }, [media, mediaType, user]); // Added user to dependency array
+  }, [media, mediaType, user, createOneTimeLink]); // include createOneTimeLink
   
   // Calculate remaining character count
   const messageValue = watch('message') || '';

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -585,7 +585,7 @@ const Message: React.FC = () => {
                             One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
                           </p>
                           <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
-                            Manage Links
+                            Manage
                           </button>
                         </div>
                       )}

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -579,20 +579,20 @@ const Message: React.FC = () => {
                           </p>
                         </div>
                       )}
-                      {id && (
-                        <div className="mt-3 border-t border-neutral-200 p-3 flex items-center justify-between dark:border-neutral-600">
-                          <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                            One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-                          </p>
-                          <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
-                            Manage
-                          </button>
-                        </div>
-                      )}
                     </div>
                   </div>
                 )}
 
+                {id && (
+                  <div className="mt-3 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
+                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
+                    </p>
+                    <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
+                      Manage
+                    </button>
+                  </div>
+                )}
 
                 {/* Passcode Display - Always show section, indicate if not set */}
                 {message && (

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -435,6 +435,20 @@ const Message: React.FC = () => {
                     Duration: {Math.floor(message.duration / 60)}:{(message.duration % 60).toString().padStart(2, '0')}
                   </p>
                 )}
+
+                {normalizedMessage && (
+                  <div className="flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
+                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
+                    </p>
+                    <button
+                      onClick={() => setIsLinksModalOpen(true)}
+                      className="text-sm text-blue-600 hover:underline"
+                    >
+                      Manage Links
+                    </button>
+                  </div>
+                )}
               </div>
           </div>
       );
@@ -577,17 +591,6 @@ const Message: React.FC = () => {
                         </p>
                       </div>
                     )}
-                    <div className="mt-2 flex items-center justify-between">
-                      <p className="text-xs text-neutral-600 dark:text-neutral-400">
-                        One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-                      </p>
-                      <button
-                        onClick={() => setIsLinksModalOpen(true)}
-                        className="text-sm text-blue-600 hover:underline"
-                      >
-                        Manage Links
-                      </button>
-                    </div>
                   </div>
                 )}
 

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -518,76 +518,78 @@ const Message: React.FC = () => {
                 {normalizedMessage.shareableLink && (
                   <div>
                     <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-white">Shareable Link</h2>
-                    <div className="flex items-center gap-2 rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
-                      <p className="flex-1 truncate text-sm text-neutral-700 dark:text-neutral-300">
-                        {normalizedMessage.shareableLink}
-                      </p>
-                      <button
-                        onClick={() => copyToClipboard(normalizedMessage.shareableLink, 'link')}
-                        className="rounded-md bg-blue-600 p-2 text-white hover:bg-blue-700"
-                      >
-                        {copied.link ? <ClipboardIcon size={16} /> : <CopyIcon size={16} />}
-                      </button>
-                      <button
-                        onClick={handleShare}
-                        className="ml-2 rounded-md bg-secondary-600 p-2 text-white hover:bg-secondary-700"
-                      >
-                        <Share2Icon size={16} />
-                      </button>
-                      <button
-                        onClick={() => setShowQrCode(!showQrCode)}
-                        aria-label={showQrCode ? 'Hide QR Code' : 'Show QR Code'}
-                        className={`ml-2 rounded-md p-2 transition-colors ${
-                          showQrCode
-                            ? 'bg-neutral-300 text-neutral-800 hover:bg-neutral-400 dark:bg-neutral-600 dark:text-white dark:hover:bg-neutral-500'
-                            : 'bg-green-600 text-white hover:bg-green-700'
-                        }`}
-                      >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-4 w-4"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z"
-                            clipRule="evenodd"
-                          />
-                          <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z" />
-                        </svg>
-                      </button>
-                    </div>
-                    {copied.link && (
-                      <p className="mt-1 text-xs text-green-600 dark:text-green-400">Link copied to clipboard!</p>
-                    )}
-                    {showQrCode && normalizedMessage.shareableLink && (
-                      <div className="mt-4 text-center">
-                        <h3 className="mb-2 text-md font-semibold text-neutral-900 dark:text-white">Scan QR Code</h3>
-                        <div className="inline-block rounded-lg bg-white p-4 shadow">
-                          <QRCodeSVG
-                            value={normalizedMessage.shareableLink}
-                            size={200}
-                            bgColor={"#ffffff"}
-                            fgColor={"#000000"}
-                            level={"L"}
-                          />
-                        </div>
-                        <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
-                          Scan this QR code to access the shareable link.
+                    <div className="rounded-md bg-neutral-100 dark:bg-neutral-700">
+                      <div className="flex items-center gap-2 p-3">
+                        <p className="flex-1 truncate text-sm text-neutral-700 dark:text-neutral-300">
+                          {normalizedMessage.shareableLink}
                         </p>
+                        <button
+                          onClick={() => copyToClipboard(normalizedMessage.shareableLink, 'link')}
+                          className="rounded-md bg-blue-600 p-2 text-white hover:bg-blue-700"
+                        >
+                          {copied.link ? <ClipboardIcon size={16} /> : <CopyIcon size={16} />}
+                        </button>
+                        <button
+                          onClick={handleShare}
+                          className="ml-2 rounded-md bg-secondary-600 p-2 text-white hover:bg-secondary-700"
+                        >
+                          <Share2Icon size={16} />
+                        </button>
+                        <button
+                          onClick={() => setShowQrCode(!showQrCode)}
+                          aria-label={showQrCode ? 'Hide QR Code' : 'Show QR Code'}
+                          className={`ml-2 rounded-md p-2 transition-colors ${
+                            showQrCode
+                              ? 'bg-neutral-300 text-neutral-800 hover:bg-neutral-400 dark:bg-neutral-600 dark:text-white dark:hover:bg-neutral-500'
+                              : 'bg-green-600 text-white hover:bg-green-700'
+                          }`}
+                        >
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="h-4 w-4"
+                            viewBox="0 0 20 20"
+                            fill="currentColor"
+                          >
+                            <path
+                              fillRule="evenodd"
+                              d="M3 4a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1V4zm2 2V5h1v1H5zM3 13a1 1 0 011-1h3a1 1 0 011 1v3a1 1 0 01-1 1H4a1 1 0 01-1-1v-3zm2 2v-1h1v1H5zM13 3a1 1 0 00-1 1v3a1 1 0 001 1h3a1 1 0 001-1V4a1 1 0 00-1-1h-3zm1 2v1h1V5h-1z"
+                              clipRule="evenodd"
+                            />
+                            <path d="M11 4a1 1 0 10-2 0v1a1 1 0 002 0V4zM10 7a1 1 0 011 1v1h2a1 1 0 110 2h-3a1 1 0 01-1-1V8a1 1 0 011-1zM16 9a1 1 0 100 2 1 1 0 000-2zM9 13a1 1 0 011-1h1a1 1 0 110 2v2a1 1 0 11-2 0v-3zM7 11a1 1 0 100-2H4a1 1 0 100 2h3zM17 13a1 1 0 01-1 1h-2a1 1 0 110-2h2a1 1 0 011 1zM16 17a1 1 0 100-2h-3a1 1 0 100 2h3z" />
+                          </svg>
+                        </button>
                       </div>
-                    )}
-                  </div>
-                )}
-                {id && (
-                  <div className="mt-4 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
-                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-                    </p>
-                    <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
-                      Manage Links
-                    </button>
+                      {copied.link && (
+                        <p className="mt-1 text-xs text-green-600 dark:text-green-400">Link copied to clipboard!</p>
+                      )}
+                      {showQrCode && normalizedMessage.shareableLink && (
+                        <div className="mt-4 text-center">
+                          <h3 className="mb-2 text-md font-semibold text-neutral-900 dark:text-white">Scan QR Code</h3>
+                          <div className="inline-block rounded-lg bg-white p-4 shadow">
+                            <QRCodeSVG
+                              value={normalizedMessage.shareableLink}
+                              size={200}
+                              bgColor={"#ffffff"}
+                              fgColor={"#000000"}
+                              level={"L"}
+                            />
+                          </div>
+                          <p className="mt-2 text-sm text-neutral-500 dark:text-neutral-400">
+                            Scan this QR code to access the shareable link.
+                          </p>
+                        </div>
+                      )}
+                      {id && (
+                        <div className="mt-3 border-t border-neutral-200 p-3 flex items-center justify-between dark:border-neutral-600">
+                          <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                            One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
+                          </p>
+                          <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
+                            Manage Links
+                          </button>
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )}
 

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -1077,6 +1077,7 @@ const Message: React.FC = () => {
           isOpen={isLinksModalOpen}
           onClose={handleLinksModalClose}
           messageId={id!}
+          passcode={message?.passcode ?? null}
         />
       </div>
     </MainLayout>

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -517,7 +517,7 @@ const Message: React.FC = () => {
               <div className="lg:grid lg:grid-cols-2 lg:gap-4 flex flex-col gap-4">
                 {normalizedMessage.shareableLink && (
                   <div>
-                    <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-white">Shareable Link</h2>
+                    <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-white">Reusable Link</h2>
                     <div className="rounded-md bg-neutral-100 dark:bg-neutral-700">
                       <div className="flex items-center gap-2 p-3">
                         <p className="flex-1 truncate text-sm text-neutral-700 dark:text-neutral-300">
@@ -584,13 +584,16 @@ const Message: React.FC = () => {
                 )}
 
                 {id && (
-                  <div className="mt-3 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
-                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-                    </p>
-                    <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
-                      Manage
-                    </button>
+                  <div>
+                    <h2 className="mb-2 mt-3 text-lg font-semibold text-neutral-900 dark:text-white">One Time Links</h2>
+                    <div className="flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
+                      <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                        Live: {linkStats.liveOneTime} / Viewed: {linkStats.expiredOneTime}
+                      </p>
+                      <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
+                        Manage
+                      </button>
+                    </div>
                   </div>
                 )}
 

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -436,19 +436,6 @@ const Message: React.FC = () => {
                   </p>
                 )}
 
-                {normalizedMessage && (
-                  <div className="flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
-                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
-                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
-                    </p>
-                    <button
-                      onClick={() => setIsLinksModalOpen(true)}
-                      className="text-sm text-blue-600 hover:underline"
-                    >
-                      Manage Links
-                    </button>
-                  </div>
-                )}
               </div>
           </div>
       );
@@ -593,6 +580,17 @@ const Message: React.FC = () => {
                     )}
                   </div>
                 )}
+                {id && (
+                  <div className="mt-4 flex items-center justify-between rounded-md bg-neutral-100 p-3 dark:bg-neutral-700">
+                    <p className="text-sm text-neutral-700 dark:text-neutral-300">
+                      One-time: {linkStats.liveOneTime} live / {linkStats.expiredOneTime} viewed
+                    </p>
+                    <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
+                      Manage Links
+                    </button>
+                  </div>
+                )}
+
 
                 {/* Passcode Display - Always show section, indicate if not set */}
                 {message && (

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -6,6 +6,7 @@ import PasscodeEntry from '../components/recipient/PasscodeEntry';
 import MessageViewer from '../components/recipient/MessageViewer';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import api, { repliesApi } from '../services/api';
+import { normalizeMessage } from '../utils/normalizeKeys';
 import { Message as MessageData } from '../types/message';
 
 const View: React.FC = () => {
@@ -44,7 +45,8 @@ const View: React.FC = () => {
           return;
         }
         const messageId = response.data.id;
-        const messageData = (await api.get(`/messages/${messageId}`)).data;
+        const rawMessageData = (await api.get(`/messages/${messageId}`)).data;
+        const messageData = normalizeMessage(rawMessageData);
         if (response.data.onetime !== undefined) {
           messageData.onetime = response.data.onetime;
         }
@@ -89,12 +91,12 @@ const View: React.FC = () => {
         setError(MESSAGE_ERRORS.LINK_EXPIRED);
         return false;
       }
-      const updatedMsg = await api.get(`/messages/${updatedView.data.id}`);
+      const updatedMsgRaw = await api.get(`/messages/${updatedView.data.id}`);
 
       if (verify.data?.verified || verify.status === 200) {
         setError(null);
         setPasscodeVerified(true);
-        if (updatedMsg.data) setMessage(updatedMsg.data);
+        if (updatedMsgRaw.data) setMessage(normalizeMessage(updatedMsgRaw.data));
         return true;
       }
       return false;

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -35,6 +35,8 @@ const View: React.FC = () => {
         return;
       }
 
+      setError(null);
+
       try {
         const response = await api.get(`/messages/view/${id}`);
         if (response.data.onetime && response.data.viewed) {
@@ -79,6 +81,7 @@ const View: React.FC = () => {
     if (!id || !message) return false;
 
     try {
+      setError(null);
       const verify = await api.post(`/messages/${id}/verify-passcode`, { passcode });
 
       const updatedView = await api.get(`/messages/view/${id}`);
@@ -89,6 +92,7 @@ const View: React.FC = () => {
       const updatedMsg = await api.get(`/messages/${updatedView.data.id}`);
 
       if (verify.data?.verified || verify.status === 200) {
+        setError(null);
         setPasscodeVerified(true);
         if (updatedMsg.data) setMessage(updatedMsg.data);
         return true;

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -39,6 +39,9 @@ const View: React.FC = () => {
         const response = await api.get(`/messages/view/${id}`);
         const messageId = response.data.id;
         const messageData = (await api.get(`/messages/${messageId}`)).data;
+        if (response.data.onetime !== undefined) {
+          messageData.onetime = response.data.onetime;
+        }
 
         const requiresPasscode = response.data.hasPasscode === true;
         const isVerified = response.data.passcodeVerified === true || !requiresPasscode;
@@ -160,6 +163,7 @@ const View: React.FC = () => {
           onSubmitPasscode={handleSubmitPasscode}
           onSendTextReply={handleSendTextReply}
           onInitReactionId={handleInitReactionId}
+          linkId={id}
         />
       </div>
     );

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -136,6 +136,43 @@ const View: React.FC = () => {
     }
   };
 
+  const renderErrorCard = (title: string, messageText?: string) => (
+    <div className="flex min-h-[100dvh] w-full flex-col items-center justify-center bg-neutral-50 px-4 py-2 dark:bg-neutral-900 sm:py-6">
+      <div className="card mx-auto max-w-md p-6 text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="h-6 w-6 text-yellow-600 dark:text-yellow-400"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+        <h3 className="text-lg font-medium text-neutral-900 dark:text-white text-center">{title}</h3>
+        {messageText && (
+          <div className="mt-4 rounded-md bg-blue-50 p-4 text-center dark:bg-blue-900/30">
+            <p className="text-sm font-medium text-blue-700 dark:text-blue-300 text-center">{messageText}</p>
+          </div>
+        )}
+        <div className="mt-6 flex justify-center">
+          <button
+            onClick={() => window.location.reload()}
+            className="btn btn-primary bg-yellow-600 hover:bg-yellow-700 dark:bg-yellow-700 dark:hover:bg-yellow-600"
+          >
+            Refresh Page
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
   if (loading) {
     return (
       <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900">
@@ -146,26 +183,13 @@ const View: React.FC = () => {
   }
 
   if (error) {
-    return (
-      <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
-        <div className="max-w-md text-center">
-          <h2 className="mt-2 text-2xl font-bold text-neutral-900 dark:text-white">
-            {error === MESSAGE_ERRORS.NOT_FOUND
-              ? 'Message Not Found'
-              : error === MESSAGE_ERRORS.LINK_EXPIRED
-                ? 'Link Expired'
-                : 'Error'}
-          </h2>
-          <p className="mt-2 text-neutral-600 dark:text-neutral-300">{error}</p>
-          <button
-            onClick={() => navigate('/')}
-            className="mt-4 inline-flex items-center rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 dark:bg-primary-700"
-          >
-            Return Home
-          </button>
-        </div>
-      </div>
-    );
+    const title =
+      error === MESSAGE_ERRORS.NOT_FOUND
+        ? 'Message Not Found'
+        : error === MESSAGE_ERRORS.LINK_EXPIRED
+          ? 'Link Expired'
+          : 'Error';
+    return renderErrorCard(title, error);
   }
 
   if (needsPasscode && !passcodeVerified) {
@@ -202,19 +226,7 @@ const View: React.FC = () => {
   }
 
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 dark:bg-neutral-900">
-      <div className="text-center">
-        <p className="text-neutral-600 dark:text-neutral-300">
-          Something went wrong. Please try again later.
-        </p>
-        <button
-          onClick={() => navigate('/')}
-          className="mt-4 inline-flex items-center rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 dark:bg-primary-700"
-        >
-          Return Home
-        </button>
-      </div>
-    </div>
+    renderErrorCard('Error', 'Something went wrong. Please try again later.')
   );
 };
 

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -196,11 +196,6 @@ const View: React.FC = () => {
     return (
       <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
         <div className="w-full max-w-md mx-auto">
-          {message?.onetime && (
-            <div className="mb-2 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
-              This link can only be viewed once.
-            </div>
-          )}
           <PasscodeEntry onSubmitPasscode={handleSubmitPasscode} />
         </div>
       </div>

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -37,10 +37,17 @@ const View: React.FC = () => {
 
       try {
         const response = await api.get(`/messages/view/${id}`);
+        if (response.data.onetime && response.data.viewed) {
+          setError(MESSAGE_ERRORS.LINK_EXPIRED);
+          return;
+        }
         const messageId = response.data.id;
         const messageData = (await api.get(`/messages/${messageId}`)).data;
         if (response.data.onetime !== undefined) {
           messageData.onetime = response.data.onetime;
+        }
+        if (response.data.viewed !== undefined) {
+          messageData.viewed = response.data.viewed;
         }
 
         const requiresPasscode = response.data.hasPasscode === true;
@@ -75,6 +82,10 @@ const View: React.FC = () => {
       const verify = await api.post(`/messages/${id}/verify-passcode`, { passcode });
 
       const updatedView = await api.get(`/messages/view/${id}`);
+      if (updatedView.data.onetime && updatedView.data.viewed) {
+        setError(MESSAGE_ERRORS.LINK_EXPIRED);
+        return false;
+      }
       const updatedMsg = await api.get(`/messages/${updatedView.data.id}`);
 
       if (verify.data?.verified || verify.status === 200) {

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -40,7 +40,7 @@ const View: React.FC = () => {
 
       try {
         const response = await api.get(`/messages/view/${id}`);
-        if (response.data.onetime && response.data.viewed) {
+        if (response.data.onetime && response.data.linkViewed) {
           setError(MESSAGE_ERRORS.LINK_EXPIRED);
           return;
         }
@@ -50,8 +50,8 @@ const View: React.FC = () => {
         if (response.data.onetime !== undefined) {
           messageData.onetime = response.data.onetime;
         }
-        if (response.data.viewed !== undefined) {
-          messageData.viewed = response.data.viewed;
+        if (response.data.linkViewed !== undefined) {
+          messageData.linkViewed = response.data.linkViewed;
         }
 
         const requiresPasscode = response.data.hasPasscode === true;
@@ -87,7 +87,7 @@ const View: React.FC = () => {
       const verify = await api.post(`/messages/${id}/verify-passcode`, { passcode });
 
       const updatedView = await api.get(`/messages/view/${id}`);
-      if (updatedView.data.onetime && updatedView.data.viewed) {
+      if (updatedView.data.onetime && updatedView.data.linkViewed) {
         setError(MESSAGE_ERRORS.LINK_EXPIRED);
         return false;
       }

--- a/src/pages/View.tsx
+++ b/src/pages/View.tsx
@@ -96,7 +96,16 @@ const View: React.FC = () => {
       if (verify.data?.verified || verify.status === 200) {
         setError(null);
         setPasscodeVerified(true);
-        if (updatedMsgRaw.data) setMessage(normalizeMessage(updatedMsgRaw.data));
+        if (updatedMsgRaw.data) {
+          const m = normalizeMessage(updatedMsgRaw.data);
+          if (updatedView.data.onetime !== undefined) {
+            m.onetime = updatedView.data.onetime;
+          }
+          if (updatedView.data.linkViewed !== undefined) {
+            m.linkViewed = updatedView.data.linkViewed;
+          }
+          setMessage(m);
+        }
         return true;
       }
       return false;
@@ -127,7 +136,6 @@ const View: React.FC = () => {
     }
   };
 
-
   if (loading) {
     return (
       <div className="flex min-h-[100dvh] flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900">
@@ -145,8 +153,8 @@ const View: React.FC = () => {
             {error === MESSAGE_ERRORS.NOT_FOUND
               ? 'Message Not Found'
               : error === MESSAGE_ERRORS.LINK_EXPIRED
-              ? 'Link Expired'
-              : 'Error'}
+                ? 'Link Expired'
+                : 'Error'}
           </h2>
           <p className="mt-2 text-neutral-600 dark:text-neutral-300">{error}</p>
           <button
@@ -163,7 +171,14 @@ const View: React.FC = () => {
   if (needsPasscode && !passcodeVerified) {
     return (
       <div className="flex min-h-[100dvh] items-center justify-center bg-neutral-50 px-4 dark:bg-neutral-900">
-        <PasscodeEntry onSubmitPasscode={handleSubmitPasscode} />
+        <div className="w-full max-w-md mx-auto">
+          {message?.onetime && (
+            <div className="mb-2 rounded-md bg-red-100 p-2 text-center text-red-700 dark:bg-red-900/40 dark:text-red-300">
+              This link can only be viewed once.
+            </div>
+          )}
+          <PasscodeEntry onSubmitPasscode={handleSubmitPasscode} />
+        </div>
       </div>
     );
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -96,11 +96,27 @@ export const messagesApi = {
   submitForManualReview: (messageId: string) => api.post(`/messages/${messageId}/manual-review`),
 };
 
+export const messageLinksApi = {
+  create: (messageId: string, onetime?: boolean) =>
+    api.post(`/messages/${messageId}/links`, { onetime }),
+  list: (messageId: string) => api.get(`/messages/${messageId}/links`),
+  delete: (linkId: string) => api.delete(`/messages/links/${linkId}`),
+};
+
 // ------------------ REACTIONS API ------------------
 export const reactionsApi = {
-  init: (messageId: string, sessionId: string, name?: string) => {
-    // CRITICAL FIX: Backend controller (messageController#initReaction) now expects `sessionid` (lowercase)
-    return api.post(`/reactions/init/${messageId}`, { sessionid: sessionId, name });
+  init: (
+    messageId: string,
+    sessionId: string,
+    name?: string,
+    linkId?: string
+  ) => {
+    // Backend expects sessionid in body and optional linkId
+    return api.post(`/reactions/init/${messageId}`, {
+      sessionid: sessionId,
+      name,
+      linkId,
+    });
   },
 
   uploadVideoToReaction: (reactionId: string, video: Blob) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -44,37 +44,6 @@ api.interceptors.response.use(
   }
 );
 
-// Debug logging interceptor to track requests and responses
-api.interceptors.request.use(config => {
-  console.log('API Request:', {
-    method: config.method,
-    url: config.url,
-    data: config.data,
-    params: config.params,
-  });
-  return config;
-});
-
-api.interceptors.response.use(
-  response => {
-    console.log('API Response:', {
-      url: response.config.url,
-      data: response.data,
-    });
-    return response;
-  },
-  error => {
-    if (error.response) {
-      console.log('API Response Error:', {
-        url: error.response.config?.url,
-        data: error.response.data,
-      });
-    } else {
-      console.log('API Response Error:', error.message);
-    }
-    return Promise.reject(error);
-  }
-);
 
 // ------------------ AUTH API ------------------
 // Note: Backend's /auth/user now returns user object with camelCase keys

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -44,6 +44,38 @@ api.interceptors.response.use(
   }
 );
 
+// Debug logging interceptor to track requests and responses
+api.interceptors.request.use(config => {
+  console.log('API Request:', {
+    method: config.method,
+    url: config.url,
+    data: config.data,
+    params: config.params,
+  });
+  return config;
+});
+
+api.interceptors.response.use(
+  response => {
+    console.log('API Response:', {
+      url: response.config.url,
+      data: response.data,
+    });
+    return response;
+  },
+  error => {
+    if (error.response) {
+      console.log('API Response Error:', {
+        url: error.response.config?.url,
+        data: error.response.data,
+      });
+    } else {
+      console.log('API Response Error:', error.message);
+    }
+    return Promise.reject(error);
+  }
+);
+
 // ------------------ AUTH API ------------------
 // Note: Backend's /auth/user now returns user object with camelCase keys
 // (e.g., response.data.user.googleId, response.data.user.createdAt)

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -16,6 +16,8 @@ export interface Message {
   url?: string;
   viewCount?: number;
   viewed?: boolean;
+  onetime?: boolean;
+  linkId?: string;
   createdAt: string;
   updatedAt?: string;
   videoUrl?: string | null;
@@ -52,5 +54,13 @@ export interface MessageFormData {
 
 export interface MessageWithReactions extends Message {
   reactions: Reaction[];
+}
+
+export interface MessageLink {
+  id: string;
+  onetime: boolean;
+  viewed: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -15,7 +15,8 @@ export interface Message {
   link?: string;
   url?: string;
   viewCount?: number;
-  viewed?: boolean;
+  viewed?: boolean; // deprecated, use linkViewed
+  linkViewed?: boolean;
   onetime?: boolean;
   linkId?: string;
   createdAt: string;
@@ -59,7 +60,8 @@ export interface MessageWithReactions extends Message {
 export interface MessageLink {
   id: string;
   onetime: boolean;
-  viewed: boolean;
+  viewed: boolean; // deprecated, use linkViewed
+  linkViewed?: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -35,6 +35,7 @@ export const normalizeMessage = (message: any) => {
     senderId: message.senderId || message.senderid,
     shareableLink: message.shareableLink || message.shareablelink,
     onetime: message.onetime ?? message.one_time,
+    viewed: message.viewed ?? message.link_viewed ?? false,
     linkId: message.linkId || message.link_id,
     fileSizeInBytes: message.fileSizeInBytes || message.mediaSize || message.file_size || undefined,
     reaction_length: message.reaction_length ?? message.reactionLength,

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -1,5 +1,16 @@
 // src/utils/normalizeKeys.ts
 
+const parseBoolean = (val: any): boolean | undefined => {
+  if (val === undefined || val === null) return undefined;
+  if (typeof val === 'boolean') return val;
+  if (typeof val === 'string') {
+    const lower = val.toLowerCase();
+    if (lower === 't' || lower === 'true') return true;
+    if (lower === 'f' || lower === 'false') return false;
+  }
+  return Boolean(val);
+};
+
 export const normalizeMessage = (message: any) => {
   if (!message) return message;
 
@@ -34,8 +45,8 @@ export const normalizeMessage = (message: any) => {
     passcode: message.passcode,
     senderId: message.senderId || message.senderid,
     shareableLink: message.shareableLink || message.shareablelink,
-    onetime: message.onetime ?? message.one_time,
-    viewed: message.viewed ?? message.link_viewed ?? false,
+    onetime: parseBoolean(message.onetime ?? message.one_time) ?? false,
+    viewed: parseBoolean(message.viewed ?? message.link_viewed) ?? false,
     linkId: message.linkId || message.link_id,
     fileSizeInBytes: message.fileSizeInBytes || message.mediaSize || message.file_size || undefined,
     reaction_length: message.reaction_length ?? message.reactionLength,

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -46,7 +46,12 @@ export const normalizeMessage = (message: any) => {
     senderId: message.senderId || message.senderid,
     shareableLink: message.shareableLink || message.shareablelink,
     onetime: parseBoolean(message.onetime ?? message.one_time) ?? false,
-    viewed: parseBoolean(message.viewed ?? message.link_viewed) ?? false,
+    viewed: parseBoolean(
+      message.viewed ?? message.link_viewed ?? message.linkViewed
+    ) ?? false,
+    linkViewed:
+      parseBoolean(message.linkViewed ?? message.link_viewed ?? message.viewed) ??
+      false,
     linkId: message.linkId || message.link_id,
     fileSizeInBytes: message.fileSizeInBytes || message.mediaSize || message.file_size || undefined,
     reaction_length: message.reaction_length ?? message.reactionLength,

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -34,6 +34,8 @@ export const normalizeMessage = (message: any) => {
     passcode: message.passcode,
     senderId: message.senderId || message.senderid,
     shareableLink: message.shareableLink || message.shareablelink,
+    onetime: message.onetime ?? message.one_time,
+    linkId: message.linkId || message.link_id,
     fileSizeInBytes: message.fileSizeInBytes || message.mediaSize || message.file_size || undefined,
     reaction_length: message.reaction_length ?? message.reactionLength,
     reactions: (message.reactions || []).map(normalizeReaction),


### PR DESCRIPTION
## Summary
- support one-time links in forms and link generator
- show one-time warning when viewing a message
- create and manage links with new modal
- expose message link APIs
- pass link id when starting reactions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_684da034023483249df4345780c27f37