### PR TITLE
Update frontend for HTTP-only auth cookie

### DIFF
--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,76 +1,45 @@
-import { useEffect, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
-import axios from 'axios';
-import api from '../services/api';
-import { setToken } from '../utils/tokenStorage';
+import { useEffect } from 'react';
 
 const AuthCallback = () => {
-  const navigate = useNavigate();
-  const [error, setError] = useState<string | null>(null);
-  const [searchParams] = useSearchParams();
-  const token = searchParams.get('token');
-  //console.log(token,"token")
-
   useEffect(() => {
-    if (token) {
-      setToken(token);
-      api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-
-      // Force a full reload to trigger AuthContext init with the new token
-      window.location.href = '/dashboard';
-    } else {
-      setError('Missing authentication token.');
-    }
-  }, [token]);
+    // Backend sets an httpOnly cookie and redirects here without a token
+    // Simply redirect to the dashboard so AuthContext can fetch the user
+    window.location.href = '/dashboard';
+  }, []);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-neutral-50 dark:bg-neutral-900">
       <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md dark:bg-neutral-800">
-        {error ? (
-          <div className="text-center">
-            <h2 className="text-2xl font-bold text-red-600 dark:text-red-400">
-              Authentication Error
-            </h2>
-            <p className="mt-2 text-neutral-600 dark:text-neutral-300">{error}</p>
-            <button
-              onClick={() => navigate('/login')}
-              className="mt-6 rounded-md bg-primary-500 px-4 py-2 text-white hover:bg-primary-600 dark:bg-primary-600 dark:hover:bg-primary-700"
+        <div className="text-center">
+          <div className="flex justify-center">
+            <svg
+              className="h-12 w-12 animate-spin text-primary-500"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
             >
-              Back to Login
-            </button>
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              ></circle>
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
           </div>
-        ) : (
-          <div className="text-center">
-            <div className="flex justify-center">
-              <svg
-                className="h-12 w-12 animate-spin text-primary-500"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="10"
-                  stroke="currentColor"
-                  strokeWidth="4"
-                ></circle>
-                <path
-                  className="opacity-75"
-                  fill="currentColor"
-                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                ></path>
-              </svg>
-            </div>
-            <h2 className="mt-4 text-2xl font-bold text-neutral-900 dark:text-white">
-              Finalizing Authentication
-            </h2>
-            <p className="mt-2 text-neutral-600 dark:text-neutral-300">
-              Please wait while we complete the sign-in process...
-            </p>
-          </div>
-        )}
+          <h2 className="mt-4 text-2xl font-bold text-neutral-900 dark:text-white">
+            Finalizing Authentication
+          </h2>
+          <p className="mt-2 text-neutral-600 dark:text-neutral-300">
+            Please wait while we complete the sign-in process...
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,6 @@ import toast from 'react-hot-toast';
 import { GENERAL_ERRORS } from '../components/constants/errorMessages';
 import type { User } from '../types/user';
 import { API_BASE_URL, REPLY_ROUTES } from '../components/constants/apiRoutes';
-import { getToken } from '../utils/tokenStorage';
 
 // Axios instance for authenticated requests
 const api = axios.create({
@@ -14,17 +13,7 @@ const api = axios.create({
   },
 });
 
-// Request interceptor to add auth token
-api.interceptors.request.use(
-  config => {
-    const token = getToken();
-    if (token) {
-      config.headers['Authorization'] = `Bearer ${token}`;
-    }
-    return config;
-  },
-  error => Promise.reject(error)
-);
+// Requests will include credentials (cookies) automatically via withCredentials
 
 // Global response error handler
 api.interceptors.response.use(


### PR DESCRIPTION
## Summary
- refactor `AuthContext` to fetch user via cookie and call `/auth/logout`
- simplify Google OAuth callback page
- remove Authorization header logic from API service

## Testing
- `npm test`
- `npm run lint` *(fails: 234 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68531cc9377c8324a2a4f508cba20643