### PR TITLE
Fix CSP header instruction and preload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ Some common TypeScript errors and solutions:
 
 The application expects a backend API at `http://localhost:8000/api`. Ensure the backend server is running and accessible.
 
+### Content Security Policy
+
+The `frame-ancestors` directive cannot be enforced through the `<meta>` tag included in `index.html`. Configure your backend server to send a `Content-Security-Policy` HTTP header that includes `frame-ancestors 'none';` (or any allowed origins). This header replaces the `<meta>` directive and ensures browsers block framing as intended.
+
 ## Key Custom Hooks
 
 ### `useAuth`

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Reactlyve - Record reactions to your surprise messages" />
     <meta name="theme-color" content="#3B82F6" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: ws:; frame-ancestors 'none'; base-uri 'self';" />
+    <!-- The frame-ancestors directive must be delivered via an HTTP header. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval'; style-src 'self' https: 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https: ws:; base-uri 'self';" />
     <meta name="referrer" content="no-referrer" />
     <link rel="stylesheet" href="/src/styles/globals.css">
     <title>Reactlyve - Surprise Message Reactions</title>
@@ -15,6 +16,6 @@
   </head>
   <body>
     <div class="app-container"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="/src/main.tsx" crossorigin="anonymous"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update index.html to clarify CSP header usage
- add `crossorigin` to the main script tag
- document CSP header requirement in README

## Testing
- `npm test`
- `npm run lint` *(fails: 223 errors, 14 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68546fc9ebf0832495d9690992c7a26a