### PR TITLE
Improve profile dropdown spacing

### DIFF
--- a/src/components/common/Navbar.tsx
+++ b/src/components/common/Navbar.tsx
@@ -107,7 +107,10 @@ const Navbar = () => {
                     <span className="sr-only">Open user menu</span>
                     <img
                       className="h-8 w-8 rounded-full"
-                      src={user.picture || `https://ui-avatars.com/api/?name=${user.name}&background=random`}
+                      src={
+                        user.picture ||
+                        `https://ui-avatars.com/api/?name=${user.name}&background=random`
+                      }
                       alt={user.name}
                     />
                   </Menu.Button>
@@ -121,10 +124,14 @@ const Navbar = () => {
                   leaveFrom="transform opacity-100 scale-100"
                   leaveTo="transform opacity-0 scale-95"
                 >
-                  <Menu.Items className="absolute right-0 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-neutral-800 dark:ring-neutral-700 z-50">
-                    <div className="border-b border-neutral-100 px-4 py-2 dark:border-neutral-700">
-                      <p className="text-sm font-medium text-neutral-900 dark:text-white">{user.name}</p>
-                      <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">{user.email}</p>
+                  <Menu.Items className="absolute right-0 mt-2 w-48 origin-top-right rounded-md bg-white py-1 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-neutral-800 dark:ring-neutral-700 z-50 divide-y divide-neutral-100 dark:divide-neutral-700">
+                    <div className="px-4 py-2">
+                      <p className="text-sm font-medium text-neutral-900 dark:text-white">
+                        {user.name}
+                      </p>
+                      <p className="truncate text-xs text-neutral-500 dark:text-neutral-400">
+                        {user.email}
+                      </p>
                     </div>
                     <Menu.Item>
                       {({ active }) => (


### PR DESCRIPTION
## Summary
- style navbar menu items with dividing lines to improve readability

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685ef6003ee083248da9d36f4d68d4e7