### PR TITLE
Fix dark theme text visibility

### DIFF
--- a/src/components/dashboard/LinksModal.tsx
+++ b/src/components/dashboard/LinksModal.tsx
@@ -126,7 +126,7 @@ const LinksModal: React.FC<LinksModalProps> = ({ isOpen, onClose, messageId, pas
               return (
                 <li key={link.id} className="rounded-md border p-2 flex flex-col">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm break-all">{url}</span>
+                    <span className="text-sm break-all text-neutral-900 dark:text-neutral-100">{url}</span>
                     <div className="flex space-x-2">
                       <Button
                         size="sm"

--- a/src/pages/Message.tsx
+++ b/src/pages/Message.tsx
@@ -590,7 +590,10 @@ const Message: React.FC = () => {
                       <p className="text-sm text-neutral-700 dark:text-neutral-300">
                         Live: {linkStats.liveOneTime} / Viewed: {linkStats.expiredOneTime}
                       </p>
-                      <button onClick={() => setIsLinksModalOpen(true)} className="text-sm text-blue-600 hover:underline">
+                      <button
+                        onClick={() => setIsLinksModalOpen(true)}
+                        className="text-sm text-blue-600 hover:underline dark:text-blue-400"
+                      >
                         Manage
                       </button>
                     </div>


### PR DESCRIPTION
## Summary
- update Manage links button text color for dark mode
- fix link color in LinksModal when dark theme enabled

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685f917be6208324aab44e3bbca068a4