### PR TITLE
Improve theme system integration

### DIFF
--- a/src/context/__tests__/ThemeContext.test.tsx
+++ b/src/context/__tests__/ThemeContext.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { ThemeProvider, useTheme } from '../ThemeContext';
 
 afterEach(() => {
@@ -34,6 +34,56 @@ describe('ThemeProvider', () => {
     const button = getByRole('button');
     expect(document.body.classList.contains('light')).toBe(true);
     fireEvent.click(button);
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+
+  it('defaults to system dark theme when no preference is stored', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({
+        matches: true,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      }),
+    });
+
+    render(
+      <ThemeProvider>
+        <div>content</div>
+      </ThemeProvider>
+    );
+
+    expect(document.body.classList.contains('dark')).toBe(true);
+  });
+
+  it('updates when system theme changes without stored preference', () => {
+    let matches = false;
+    const listeners: Array<(e: MediaQueryListEvent) => void> = [];
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockReturnValue({
+        get matches() {
+          return matches;
+        },
+        addEventListener: jest.fn((_event, cb) => listeners.push(cb)),
+        removeEventListener: jest.fn(),
+      }),
+    });
+
+    render(
+      <ThemeProvider>
+        <div>content</div>
+      </ThemeProvider>
+    );
+
+    expect(document.body.classList.contains('light')).toBe(true);
+
+    matches = true;
+    act(() => {
+      listeners.forEach(cb => cb({ matches } as MediaQueryListEvent));
+    });
+
     expect(document.body.classList.contains('dark')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- sync `ThemeProvider` with system theme when no user preference exists
- preserve user preference to localStorage only after a manual toggle
- listen for system theme changes and update accordingly
- update theme tests for new behavior

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fbe5edd7c8324b1385e8e16ca91a8