### PR TITLE
Implement 5‑minute theme cookie

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,14 +23,20 @@
   </head>
   <body>
     <script>
-      const storedTheme = localStorage.getItem('theme');
+      function getCookie(name) {
+        const match = document.cookie.match(new RegExp('(^|;\\s*)' + name + '=([^;]*)'));
+        return match ? decodeURIComponent(match[2]) : null;
+      }
+      function setCookie(name, value, minutes) {
+        const expires = new Date(Date.now() + minutes * 60 * 1000).toUTCString();
+        document.cookie = name + '=' + encodeURIComponent(value) + '; expires=' + expires + '; path=/';
+      }
+
       const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const theme =
-        storedTheme === 'light' || storedTheme === 'dark'
-          ? storedTheme
-          : prefersDark
-            ? 'dark'
-            : 'light';
+      const systemTheme = prefersDark ? 'dark' : 'light';
+      const storedTheme = getCookie('theme');
+      const theme = storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : systemTheme;
+      setCookie('theme', theme, 5);
       document.body.classList.add(theme);
     </script>
     <div class="app-container"></div>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react';
+import { getCookie, setCookie } from '../utils/cookies';
 
 type Theme = 'light' | 'dark';
 
@@ -11,33 +12,30 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'dark' || storedTheme === 'light') {
-      return storedTheme;
-    }
-
-    if (
+    const prefersDark =
       typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-    ) {
-      return 'dark';
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const systemTheme: Theme = prefersDark ? 'dark' : 'light';
+
+    const storedTheme = getCookie('theme');
+    if (storedTheme === 'dark' || storedTheme === 'light') {
+      return storedTheme as Theme;
     }
 
-    return 'light';
+    return systemTheme;
   });
 
   const [hasUserPreference, setHasUserPreference] = useState(() => {
-    const storedTheme = localStorage.getItem('theme');
+    const storedTheme = getCookie('theme');
     return storedTheme === 'dark' || storedTheme === 'light';
   });
 
   useEffect(() => {
-    if (hasUserPreference) {
-      localStorage.setItem('theme', theme);
-    }
+    setCookie('theme', theme, 5); // refresh cookie on every load/change
     document.body.classList.remove('light', 'dark');
     document.body.classList.add(theme);
-  }, [theme, hasUserPreference]);
+  }, [theme]);
 
   useEffect(() => {
     if (hasUserPreference) return;

--- a/src/context/__tests__/ThemeContext.test.tsx
+++ b/src/context/__tests__/ThemeContext.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 import { ThemeProvider, useTheme } from '../ThemeContext';
 
 afterEach(() => {
-  localStorage.clear();
+  document.cookie = 'theme=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
   document.body.className = '';
   jest.restoreAllMocks();
 });
@@ -15,7 +15,7 @@ function TestComponent() {
 
 describe('ThemeProvider', () => {
   it('applies stored dark theme to the body', () => {
-    localStorage.setItem('theme', 'dark');
+    document.cookie = 'theme=dark';
     render(
       <ThemeProvider>
         <div>content</div>
@@ -25,7 +25,7 @@ describe('ThemeProvider', () => {
   });
 
   it('toggles theme classes when toggleTheme is called', () => {
-    localStorage.setItem('theme', 'light');
+    document.cookie = 'theme=light';
     const { getByRole } = render(
       <ThemeProvider>
         <TestComponent />

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,0 +1,16 @@
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp('(^|;\\s*)' + name + '=([^;]*)'));
+  return match ? decodeURIComponent(match[2]) : null;
+}
+
+export function setCookie(name: string, value: string, minutes: number) {
+  if (typeof document === 'undefined') return;
+  const expires = new Date(Date.now() + minutes * 60 * 1000).toUTCString();
+  document.cookie = `${name}=${encodeURIComponent(value)}; expires=${expires}; path=/`;
+}
+
+export function deleteCookie(name: string) {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+}


### PR DESCRIPTION
## Summary
- add cookie helpers
- switch ThemeProvider to use cookies instead of localStorage
- persist the theme cookie for 5 minutes on each load
- update the initial theme script in `index.html`
- update tests for the new cookie behaviour

## Testing
- `npm test --silent`
- `npm run lint` *(fails: many pre-existing errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685fc1e0a96c83248d2066b106aff741