### PR TITLE
Add download links for media

### DIFF
--- a/src/components/dashboard/ReactionViewer.tsx
+++ b/src/components/dashboard/ReactionViewer.tsx
@@ -68,13 +68,13 @@ const ReactionViewer: React.FC<ReactionViewerProps> = ({
               </Button>
 
               <a
-                href={transformedVideoUrl || '#'}
-                download={`reaction-${reaction.id}.${transformedVideoUrl?.split('.').pop()?.split('?')[0] || 'webm'}`}
+                href={reaction.downloadUrl}
+                download
                 className={classNames(
                   "btn btn-outline btn-sm",
-                  !transformedVideoUrl && "btn-disabled opacity-50 cursor-not-allowed"
+                  !reaction.downloadUrl && "btn-disabled opacity-50 cursor-not-allowed"
                 )}
-                aria-disabled={!transformedVideoUrl}
+                aria-disabled={!reaction.downloadUrl}
               >
                 Download
               </a>

--- a/src/pages/Reaction.tsx
+++ b/src/pages/Reaction.tsx
@@ -79,22 +79,6 @@ const ReactionPage: React.FC = () => {
     fetchReactionAndMessage();
   }, [reactionId]);
 
-  const downloadVideo = async (url: string, filename: string) => {
-    try {
-      const res = await fetch(url);
-      const blob = await res.blob();
-      const blobUrl = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = blobUrl;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(blobUrl);
-    } catch (err) {
-      console.error('Download error:', err);
-    }
-  };
 
   if (loading) {
     return (
@@ -185,53 +169,16 @@ const ReactionPage: React.FC = () => {
               typeof reaction?.duration === 'number' ? reaction.duration : undefined
             }
           />
-          <button
-            onClick={() => {
-              if (processedVideoUrl) {
-                const prefix = 'Reactlyve';
-                let titlePart = 'video';
-                if (parentMessage && parentMessage.content) {
-                  titlePart = parentMessage.content.replace(/\s+/g, '_').substring(0, 5);
-                }
-                const responderNamePart = reaction?.name
-                  ? reaction.name.replace(/\s+/g, '_')
-                  : 'UnknownResponder';
-                let dateTimePart = 'timestamp';
-                if (reaction?.createdAt) {
-                  try {
-                    dateTimePart = format(new Date(reaction.createdAt), 'ddMMyyyy-HHmm');
-                  } catch (e) {
-                    console.error('Error formatting date for filename:', e);
-                  }
-                }
-                let extension = 'mp4'; // Default to mp4
-                if (processedVideoUrl) {
-                  // Redundant check, but safe
-                  try {
-                    const urlPath = new URL(processedVideoUrl).pathname;
-                    const lastSegment = urlPath.substring(urlPath.lastIndexOf('/') + 1);
-                    if (lastSegment.includes('.')) {
-                      const ext = lastSegment.split('.').pop()?.split('?')[0];
-                      if (ext) extension = ext;
-                    }
-                  } catch (e) {
-                    console.error('Could not parse processed video URL for extension:', e);
-                  }
-                }
-                const nameWithoutExtension = `${prefix}-${titlePart}-${responderNamePart}-${dateTimePart}`;
-                const sanitizedName = nameWithoutExtension.replace(/[^a-zA-Z0-9_\-\.]/g, '_');
-                const finalFilename = `${sanitizedName}.${extension}`;
-                downloadVideo(processedVideoUrl, finalFilename);
-              } else {
-                toast.error('Download URL is not available');
-              }
-            }}
-            className="mt-4 flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
-            disabled={!processedVideoUrl}
-          >
-            <DownloadIcon size={16} />
-            Download Video
-          </button>
+              {reaction.downloadUrl && (
+                <a
+                  href={reaction.downloadUrl}
+                  download
+                  className="mt-4 inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+                >
+                  <DownloadIcon size={16} />
+                  Download Video
+                </a>
+              )}
         </div>
       ) : (
         reaction?.moderationStatus !== 'rejected' &&
@@ -272,6 +219,15 @@ const ReactionPage: React.FC = () => {
                 <span className="text-xs text-neutral-500">
                   ({new Date(reply.createdAt).toLocaleString()})
                 </span>
+                {reply.downloadUrl && (
+                  <a
+                    href={reply.downloadUrl}
+                    download
+                    className="ml-2 text-blue-600 hover:underline"
+                  >
+                    Download
+                  </a>
+                )}
               </li>
             ))}
           </ul>

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -24,6 +24,7 @@ export interface Message {
   videoUrl?: string | null;
   mediaType?: 'image' | 'video';
   duration?: number;
+  downloadUrl?: string;
   reaction_length?: number;
   max_reactions_allowed?: number | null; // Add this line
   reactions_used?: number;
@@ -47,6 +48,7 @@ export interface Reply {
   mediaType?: string | null;
   thumbnailUrl?: string | null;
   duration?: number;
+  downloadUrl?: string;
   createdAt: string;
 }
 

--- a/src/types/reaction.ts
+++ b/src/types/reaction.ts
@@ -14,6 +14,7 @@ export interface Reaction {
   /** Normalized camelCase fields */
   moderationStatus?: string | null;
   moderationDetails?: string | null;
+  downloadUrl?: string;
   replies?: Reply[];
 }
 

--- a/src/utils/cloudinaryUtils.ts
+++ b/src/utils/cloudinaryUtils.ts
@@ -1,0 +1,16 @@
+export const generateDownloadUrl = (cloudinaryUrl: string, filename: string): string => {
+  if (typeof cloudinaryUrl !== 'string') return '';
+  try {
+    const url = new URL(cloudinaryUrl);
+    const segments = url.pathname.split('/');
+    const uploadIndex = segments.indexOf('upload');
+    if (uploadIndex !== -1) {
+      segments.splice(uploadIndex + 1, 0, `fl_attachment:${filename}`);
+      url.pathname = segments.join('/');
+    }
+    return url.toString();
+  } catch (err) {
+    console.error('Failed to generate download URL:', err);
+    return cloudinaryUrl;
+  }
+};

--- a/src/utils/normalizeKeys.ts
+++ b/src/utils/normalizeKeys.ts
@@ -40,6 +40,7 @@ export const normalizeMessage = (message: any) => {
     imageUrl: finalImageUrl,
     videoUrl: finalVideoUrl,
     thumbnailUrl: message.thumbnailUrl || message.thumbnailurl,
+    downloadUrl: message.downloadUrl || message.download_url || message.downloadurl,
     createdAt: message.createdAt || message.createdat,
     updatedAt: message.updatedAt || message.updatedat,
     passcode: message.passcode,
@@ -80,6 +81,7 @@ export const normalizeReply = (reply: any) => {
       reply.durationSecs ||
       reply.duration_secs ||
       undefined,
+    downloadUrl: reply.downloadUrl || reply.download_url || reply.downloadurl,
     createdAt: reply.createdAt || reply.createdat,
   };
 };
@@ -95,6 +97,7 @@ export const normalizeReaction = (reaction: any) => {
     updatedAt: reaction.updatedAt || reaction.updatedat,
     videoUrl: reaction.videoUrl || reaction.videourl,
     thumbnailUrl: reaction.thumbnailUrl || reaction.thumbnailurl,
+    downloadUrl: reaction.downloadUrl || reaction.download_url || reaction.downloadurl,
     duration: reaction.duration || reaction.videoDuration || reaction.video_duration || reaction.durationInSecs || undefined,
     replies: (reaction.replies || []).map(normalizeReply),
     moderationStatus:


### PR DESCRIPTION
## Summary
- add Cloudinary download URL helper
- expand message, reaction, and reply types with downloadUrl field
- include downloadUrl in key normalizers
- update components to show download links instead of manual downloads

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860edd160ac8324b030c1bfb8725922