### PR TITLE
Fix video reply prompt visibility

### DIFF
--- a/src/components/recipient/WebcamRecorder.tsx
+++ b/src/components/recipient/WebcamRecorder.tsx
@@ -555,7 +555,7 @@ const WebcamRecorder: React.FC<WebcamRecorderProps> = ({
           className || ''
         )}
       >
-        {!(showCountdown || isRecording || recordingCompleted || isCompressing) && (
+        {!(showCountdown || isRecording || recordingCompleted || isCompressing) && !isReplyMode && (
           <h2 className="mb-1 text-lg font-semibold text-neutral-900 dark:text-neutral-100">Record Your Lyve Reaction</h2>
         )}
 


### PR DESCRIPTION
## Summary
- hide "Record Your Lyve Reaction" header when recording a video reply

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: many lint errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686128b159f88324a8c1595bc8c5973e